### PR TITLE
Add Coverity scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LCIO
 
 [![Build Status](https://travis-ci.org/iLCSoft/LCIO.svg?branch=master)](https://travis-ci.org/iLCSoft/LCIO)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/11178/badge.svg)](https://scan.coverity.com/projects/ilcsoft-lcio)
 
 LCIO ( **L**inear **C**ollider **I/O** ) provides the event data model (EDM) and 
 persistency solution for Linear Collider detector R&D studies.


### PR DESCRIPTION
Configured Coverity scan, but defects not visible immediately due to:
```
While we review your project application you cannot view defects.
It takes about 1-2 business day to review your association with the project and to make sure project meets open source guidelines.
```