### PR TITLE
Add back CellIDDecoder.h 

### DIFF
--- a/src/cpp/include/UTIL/ILDConf.h
+++ b/src/cpp/include/UTIL/ILDConf.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include "CellIDEncoder.h"
+#include "CellIDDecoder.h"
 #include "LCTrackerConf.h"
 
 


### PR DESCRIPTION
iLCSoft installation breaks (MarlinTrk) because lcio namespace is missing since it's coming from the [header file](https://github.com/iLCSoft/LCIO/blob/master/src/cpp/include/UTIL/CellIDDecoder.h#L18)