### PR TITLE
Remove the Parrot Connector and mount cvmfs directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,22 @@ env:
     - COMPILER=gcc
     - COMPILER=llvm
 
+
+before_install:
+  - wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+  - sudo dpkg -i cvmfs-release-latest_all.deb
+  - sudo apt-get update
+  - sudo apt-get install cvmfs cvmfs-config-default
+  - rm -f cvmfs-release-latest_all.deb
+  - wget https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
+  - sudo mkdir -p /etc/cvmfs
+  - sudo mv default.local /etc/cvmfs/default.local
+  - sudo /etc/init.d/autofs stop
+  - sudo cvmfs_config setup
+  - sudo mkdir -p /cvmfs/clicdp.cern.ch
+  - sudo mount -t cvmfs clicdp.cern.ch /cvmfs/clicdp.cern.ch
+  - ls /cvmfs/clicdp.cern.ch
+
 # command to install dependencies
 install:
   - shopt -s extglob dotglob
@@ -18,12 +34,12 @@ install:
   - mv !(Package) Package
   - shopt -u dotglob
   - export PKGDIR=${PWD}/Package
-  - curl -O https://lcd-data.web.cern.ch/lcd-data/CernVM/cernvm3-docker-latest.tar
-  - cat cernvm3-docker-latest.tar | docker import - cernvm
 
 # command to run tests
 script:
-  - docker run -t -v $PKGDIR:/Package -e COMPILER=$COMPILER cernvm /init /Package/.travis-ci.d/compile_and_test.sh
+  - docker run -it --name CI_container -v $PKGDIR:/Package -e COMPILER=$COMPILER -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch -d clicdp/slc6-build /bin/bash
+  - docker exec -it CI_container /bin/bash -c "./Package/.travis-ci.d/compile_and_test.sh"
+
 
 # Don't send e-mail notifications
 notifications:


### PR DESCRIPTION
BEGINRELEASENOTES
- Update to the CI system:
  - Install directly cvmfs on base system, which removes the need for the parrot connector 
  - Replace CernVM docker with plain docker
  - This reduces the build run time from 15 min to 5 min

ENDRELEASENOTES