### PR TITLE
Fix effcpp warnings

### DIFF
--- a/cmake/ilcsoft_default_cxx_flags.cmake
+++ b/cmake/ilcsoft_default_cxx_flags.cmake
@@ -4,7 +4,7 @@
 
 INCLUDE(CheckCXXCompilerFlag)
 
-SET(COMPILER_FLAGS -Wall -Wextra -Wshadow -Weffc++ -pedantic -Wno-long-long -Wuninitialized )
+SET(COMPILER_FLAGS -Wall -Wextra -Wshadow -Weffc++ -pedantic -Wno-long-long -Wuninitialized -Wno-non-virtual-dtor)
 
 IF( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
  LIST( APPEND COMPILER_FLAGS -Wl,-no-undefined )

--- a/sio/include/SIO_stream.h
+++ b/sio/include/SIO_stream.h
@@ -106,33 +106,33 @@ private:
 
     unsigned int           write( SIO_record*, const char* );
 
-    unsigned char*         bufloc;        // Buffer pointer (beginning)
-    unsigned char*         buffer;        // Buffer pointer (current)
-    unsigned char*         bufmax;        // Buffer pointer (end)
-    unsigned char*         recmax;        // Record pointer (end)
-    unsigned char*         blkmax;        // Block  pointer (end)
+    unsigned char*         bufloc{NULL};    // Buffer pointer (beginning)
+    unsigned char*         buffer{NULL};    // Buffer pointer (current)
+    unsigned char*         bufmax{NULL};    // Buffer pointer (end)
+    unsigned char*         recmax{NULL};    // Record pointer (end)
+    unsigned char*         blkmax{NULL};    // Block  pointer (end)
 
-    unsigned char*         cmploc;        // Compression buffer pointer (beg)
-    unsigned char*         cmpmax;        // Compression buffer pointer (end)
-    struct z_stream_s*     z_strm;        // Compression buffer control
+    unsigned char*         cmploc{NULL};    // Compression buffer pointer (beg)
+    unsigned char*         cmpmax{NULL};    // Compression buffer pointer (end)
+    struct z_stream_s*     z_strm{NULL};    // Compression buffer control
 
-    std::string            name;          // Stream's name
-    std::string            filename;      // Stream's associated file
-    FILE*                  handle;        // File handle
+    std::string            name{};          // Stream's name
+    std::string            filename{};      // Stream's associated file
+    FILE*                  handle{NULL};    // File handle
 
-    std::string            rec_name;      // Record name being read
-    std::string            blk_name;      // Block  name being read
+    std::string            rec_name{};      // Record name being read
+    std::string            blk_name{};      // Block  name being read
 
-    pointedAtMap_c*        pointedAt;     // Map      of 'pointed at'
-    pointerToMap_c*        pointerTo;     // Multimap of 'pointer to'
+    pointedAtMap_c*        pointedAt{NULL}; // Map      of 'pointed at'
+    pointerToMap_c*        pointerTo{NULL}; // Multimap of 'pointer to'
 
-    SIO_stream_mode        mode;          // Stream mode
-    unsigned int           reserve;       // Reserved size of buffer
-    SIO_stream_state       state;         // Stream state  
-    SIO_verbosity          verbosity;     // Reporting level
+    SIO_stream_mode        mode{SIO_MODE_UNDEFINED};   // Stream mode
+    unsigned int           reserve{0};                 // Reserved size of buffer
+    SIO_stream_state       state{SIO_STATE_CLOSED};    // Stream state  
+    SIO_verbosity          verbosity{};                // Reporting level
 
-    SIO_64BITINT           recPos  ;      // start Position of last record read
-    int                    compLevel ;    // compression level
+    SIO_64BITINT           recPos{0}  ;     // start Position of last record read
+    int                    compLevel{0} ;   // compression level
 
 friend class SIO_streamManager;           // Access to constructor/destructor
 friend class SIO_record;                  // Access to buffer

--- a/sio/src/SIO_stream.cc
+++ b/sio/src/SIO_stream.cc
@@ -41,34 +41,11 @@ SIO_stream::SIO_stream
     const char*      i_name,
     unsigned int     i_reserve,
     SIO_verbosity    i_verbosity
-)
-{
-
-bufloc    = NULL;
-buffer    = NULL;
-bufmax    = NULL;
-recmax    = NULL;
-blkmax    = NULL;
-
-cmploc    = NULL;
-cmpmax    = NULL;
-z_strm    = NULL;
-
-name      = i_name;
-handle    = NULL;
-
-mode      = SIO_MODE_UNDEFINED;
-reserve   = i_reserve;
-state     = SIO_STATE_CLOSED;
-verbosity = i_verbosity;
-
-pointedAt = NULL ;
-pointerTo = NULL ;
-
-recPos = 0 ;
-
-compLevel = Z_DEFAULT_COMPRESSION ;
-}
+ ) : name( i_name ),
+	 reserve( i_reserve ),
+	 verbosity( i_verbosity ),
+	 compLevel(Z_DEFAULT_COMPRESSION) 
+{}
 
 // ----------------------------------------------------------------------------
 // Destructor (private function!)

--- a/src/aid/EVENT/LCFloatVec.aid
+++ b/src/aid/EVENT/LCFloatVec.aid
@@ -22,9 +22,9 @@ public interface LCFloatVec extends LCObject
     typedef LCFloatVec lcobject_type ;
 
     public:
-    int id() const { return _acc.simpleUID() ; } 
+      int id() const { return _acc.simpleUID() ; } 
     protected:
-      IMPL::AccessChecked _acc ;
+      IMPL::AccessChecked _acc{} ;
 }
 
 

--- a/src/aid/EVENT/LCIntVec.aid
+++ b/src/aid/EVENT/LCIntVec.aid
@@ -23,7 +23,7 @@ public interface LCIntVec extends LCObject
     public:
     int id() const { return _acc.simpleUID() ; } 
     protected:
-      IMPL::AccessChecked _acc ;
+      IMPL::AccessChecked _acc{} ;
 }
 
 @ifdef java

--- a/src/aid/EVENT/LCStrVec.aid
+++ b/src/aid/EVENT/LCStrVec.aid
@@ -23,7 +23,7 @@ public interface LCStrVec extends LCObject
     public:
     int id() const { return _acc.simpleUID() ; } 
     protected:
-      IMPL::AccessChecked _acc ;
+      IMPL::AccessChecked _acc{} ;
 }
 
 @ifdef java

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -397,7 +397,7 @@ IF( BUILD_ROOTDICT )
     # ------ build lcioDict library ---------------------------------
 
     INCLUDE_DIRECTORIES( "${ROOT_DICT_OUTPUT_DIR}" )
-    INCLUDE_DIRECTORIES( "${ROOT_INCLUDE_DIRS}" )
+    INCLUDE_DIRECTORIES( SYSTEM "${ROOT_INCLUDE_DIRS}" )
 
     ADD_SHARED_LIBRARY( lcioDict ${lcio_rootdict_sources} )
     TARGET_LINK_LIBRARIES( lcioDict ${ROOT_LIBRARIES} lcio )

--- a/src/cpp/include/Exceptions.h
+++ b/src/cpp/include/Exceptions.h
@@ -22,7 +22,7 @@ namespace EVENT {
 
     
   protected:
-    std::string message ;
+    std::string message{} ;
     
     Exception(){  /*no_op*/ ; } 
     

--- a/src/cpp/include/IMPL/AccessChecked.h
+++ b/src/cpp/include/IMPL/AccessChecked.h
@@ -31,8 +31,8 @@ namespace IMPL {
     void checkAccess(const char* what) throw ( EVENT::ReadOnlyException ) ;
 
   protected: 
-    bool _readOnly ;
-    int _id ;
+    bool _readOnly{false} ;
+    int _id{-1} ;
     
   };
 } // namespace IMPL

--- a/src/cpp/include/IMPL/CalorimeterHitImpl.h
+++ b/src/cpp/include/IMPL/CalorimeterHitImpl.h
@@ -24,9 +24,8 @@ namespace IMPL {
      */
     CalorimeterHitImpl() ;
 
-    /** Copy constructor. Not yet - needs pointer chasing ... 
-     */
-    //    CalorimeterHitImpl(const CalorimeterHit& hit) ;
+    CalorimeterHitImpl(const IMPL::CalorimeterHitImpl&) = default ;
+    CalorimeterHitImpl& operator=(const IMPL::CalorimeterHitImpl&) = default ;
 
     /// Destructor.
     virtual ~CalorimeterHitImpl() ;

--- a/src/cpp/include/IMPL/ClusterImpl.h
+++ b/src/cpp/include/IMPL/ClusterImpl.h
@@ -143,22 +143,20 @@ namespace IMPL {
   protected:
     void setType(int type ) ; 
 
-    //    int _type ;
-    //    std::string _type ;
-    std::bitset<32> _type ;
-    float _energy ;
-    float _energyError ;
-    float _position[3] ;
+    std::bitset<32> _type{0} ;
+    float _energy{0} ;
+    float _energyError{0} ;
+    float _position[3]={0,0,0} ;
     EVENT::FloatVec _errpos ;
-    float _theta;
-    float _phi ;
+    float _theta{0};
+    float _phi{0} ;
     EVENT::FloatVec _errdir ;
-    EVENT::FloatVec _shape ;
-    EVENT::ParticleIDVec _pid ;
-    EVENT::ClusterVec _clusters ;
-    EVENT::CalorimeterHitVec _hits ;
-    EVENT::FloatVec _weights ;
-    EVENT::FloatVec _subdetectorEnergies ;
+    EVENT::FloatVec _shape{} ;
+    EVENT::ParticleIDVec _pid{} ;
+    EVENT::ClusterVec _clusters{} ;
+    EVENT::CalorimeterHitVec _hits{} ;
+    EVENT::FloatVec _weights{} ;
+    EVENT::FloatVec _subdetectorEnergies{} ;
 
 }; // class
 

--- a/src/cpp/include/IMPL/LCCollectionVec.h
+++ b/src/cpp/include/IMPL/LCCollectionVec.h
@@ -13,7 +13,6 @@
 
 namespace IMPL {
   
-  //  typedef std::vector<EVENT::LCObject*> LCObjectVec ;
 
   /** Implementation of the LCCollection using (inheriting from) an STL vector
    *  of LCObjects.
@@ -27,12 +26,12 @@ namespace IMPL {
     , public AccessChecked {
     
     
-   public: // this is needed for the auto generated streamer in the ROOT dictionary !!!
-    //protected 
-    /**  Default Constructor should be protected - every LCCollection needs to know the type
-     *   of its elements.
+   public: 
+    /**  Default Constructor - don't use - only public for auto-generated streamers 
+     *   in the ROOT dictionary !! Should be protected really. 
+     *   Every LCCollection needs to know the type of its elements.
      */
-    LCCollectionVec() : _flag(0) {  /* no default c'tor */ }
+    LCCollectionVec() :  _typeName("UNKNOWN" ), _flag(0) { }
     
   public:
     
@@ -149,8 +148,7 @@ namespace IMPL {
 
     std::string _typeName ;
     int _flag ;
-    LCParametersImpl _params ;
-    //    int _access ;
+    LCParametersImpl _params{} ;
 
 }; // class
 } // namespace IMPL

--- a/src/cpp/include/IMPL/LCEventImpl.h
+++ b/src/cpp/include/IMPL/LCEventImpl.h
@@ -173,13 +173,13 @@ namespace IMPL{
     std::string _detectorName ;
     
     // map has to be defined mutable in order to use _map[]  for const methods ...
-    mutable LCCollectionMap _colMap ;
-    mutable std::vector<std::string> _colNames ;
+    mutable LCCollectionMap _colMap{} ;
+    mutable std::vector<std::string> _colNames{} ;
     
-    LCParametersImpl _params ;
+    LCParametersImpl _params{} ;
     
     // set of collections that are not owned by the event anymore
-    mutable LCCollectionSet _notOwned ;
+    mutable LCCollectionSet _notOwned{} ;
     
 
   }; // class

--- a/src/cpp/include/IMPL/LCGenericObjectImpl.h
+++ b/src/cpp/include/IMPL/LCGenericObjectImpl.h
@@ -89,10 +89,10 @@ public:
 
 protected:
   
-  std::vector<int> _intVec ;
-  std::vector<float> _floatVec ;
-  std::vector<double> _doubleVec ;
-  bool _isFixedSize ;
+  std::vector<int> _intVec{} ;
+  std::vector<float> _floatVec{} ;
+  std::vector<double> _doubleVec{} ;
+  bool _isFixedSize{false} ;
 
   static std::string _typeName ;
   static std::string _dataDescription ;

--- a/src/cpp/include/IMPL/LCParametersImpl.h
+++ b/src/cpp/include/IMPL/LCParametersImpl.h
@@ -123,9 +123,9 @@ namespace IMPL {
 
   protected:
 
-    mutable IntMap _intMap ;
-    mutable FloatMap _floatMap ;
-    mutable StringMap _stringMap ;
+    mutable IntMap _intMap{} ;
+    mutable FloatMap _floatMap{} ;
+    mutable StringMap _stringMap{} ;
     
   }; // class
 } // namespace IMPL

--- a/src/cpp/include/IMPL/LCRelationImpl.h
+++ b/src/cpp/include/IMPL/LCRelationImpl.h
@@ -26,6 +26,12 @@ namespace IMPL {
     LCRelationImpl( EVENT::LCObject* from, EVENT::LCObject* to , float weight=1.0f ) : _from(from),
 											  _to(to),
 											  _weight(weight) {}
+    /// default copy constructor - use with care
+    LCRelationImpl(const LCRelationImpl&) = default ;
+
+    /// default assignment operator - use with care
+    LCRelationImpl& operator=(const LCRelationImpl&) = default ;
+
     ~LCRelationImpl(){}
 
     int id() const { return simpleUID() ; }

--- a/src/cpp/include/IMPL/LCRunHeaderImpl.h
+++ b/src/cpp/include/IMPL/LCRunHeaderImpl.h
@@ -77,12 +77,12 @@ namespace IMPL {
 
   protected:
     
-    int _runNumber ;
-    std::string _detectorName ;
-    std::string _description ;
-    std::vector<std::string> _activeSubdetectors ;
+    int _runNumber{0} ;
+    std::string _detectorName{} ;
+    std::string _description{} ;
+    std::vector<std::string> _activeSubdetectors{} ;
 
-    LCParametersImpl _params ;
+    LCParametersImpl _params{} ;
 
   }; // class
 } // namespace IMPL

--- a/src/cpp/include/IMPL/ParticleIDImpl.h
+++ b/src/cpp/include/IMPL/ParticleIDImpl.h
@@ -11,8 +11,7 @@ namespace IMPL {
 
   /** Helper class to sort ParticleIDs wrt. their likelihood.
    */
-  class PIDSort : public std::binary_function<EVENT::ParticleID*,EVENT::ParticleID*,bool>{
-  public:
+  struct PIDSort{
     bool operator()(const EVENT::ParticleID* p1, const EVENT::ParticleID* p2){
       return p1->getLikelihood() > p2->getLikelihood() ;
     }
@@ -78,7 +77,7 @@ namespace IMPL {
     int _pdg ;
     float _likelihood ;
     int _algorithmType ;
-    EVENT::FloatVec _parameters ;
+    EVENT::FloatVec _parameters{} ;
 
 }; // class
 

--- a/src/cpp/include/IMPL/ReconstructedParticleImpl.h
+++ b/src/cpp/include/IMPL/ReconstructedParticleImpl.h
@@ -27,6 +27,12 @@ namespace IMPL {
      */
     ReconstructedParticleImpl() ;
     
+    /// default copy constructor - use with care
+    ReconstructedParticleImpl(const ReconstructedParticleImpl&) = default ;
+
+    /// default assignment operator - use with care
+    ReconstructedParticleImpl& operator=(const ReconstructedParticleImpl&) = default ;
+
     /// Destructor.
     virtual ~ReconstructedParticleImpl() ; 
 
@@ -129,20 +135,20 @@ namespace IMPL {
 
   protected:
 
-    int _type ;
-    double _momentum[3] ;
-    double _energy ;
-    EVENT::FloatVec _cov ;
-    double _mass ;
-    float _charge ;
-    float _reference[3] ;
-    EVENT::ParticleID* _pidUsed ;
-    float _goodnessOfPID ;
-    EVENT::ParticleIDVec _pid ;
-    EVENT::ReconstructedParticleVec _particles ;
-    EVENT::ClusterVec _clusters ;
-    EVENT::TrackVec _tracks ;
-    EVENT::Vertex* _sv ;
+    int _type{0} ;
+    double _momentum[3] = {0.,0.,0.} ;
+    double _energy{0.} ;
+    EVENT::FloatVec _cov{} ;
+    double _mass{0.} ;
+    float _charge{} ;
+    float _reference[3] = {0.,0.,0.}  ;
+    EVENT::ParticleID* _pidUsed{ NULL} ;
+    float _goodnessOfPID{0.} ;
+    EVENT::ParticleIDVec _pid{} ;
+    EVENT::ReconstructedParticleVec _particles{} ;
+    EVENT::ClusterVec _clusters{} ;
+    EVENT::TrackVec _tracks{} ;
+    EVENT::Vertex* _sv{} ;
 
     
 }; // class

--- a/src/cpp/include/IMPL/SimCalorimeterHitImpl.h
+++ b/src/cpp/include/IMPL/SimCalorimeterHitImpl.h
@@ -194,7 +194,7 @@ namespace IMPL {
     float _energy ;
     float _position[3] ;
 
-    MCParticleContVec _vec ;
+    MCParticleContVec _vec{} ;
     
   }; // class
 } // namespace IMPL

--- a/src/cpp/include/IMPL/SimTrackerHitImpl.h
+++ b/src/cpp/include/IMPL/SimTrackerHitImpl.h
@@ -24,7 +24,13 @@ namespace IMPL {
     /** Default constructor, initializes values to 0.
      */
     SimTrackerHitImpl() ;
-    
+
+    /// default copy constructor - use with care
+    SimTrackerHitImpl(const SimTrackerHitImpl&) = default ;
+
+    /// default assignment operator - use with care
+    SimTrackerHitImpl& operator=(const SimTrackerHitImpl&) = default ;
+
     /// Destructor.
     virtual ~SimTrackerHitImpl() ; 
     
@@ -86,9 +92,6 @@ namespace IMPL {
     virtual int getQuality() const { return _quality ; }
 
     // ---------- setters ------------------------
-    /** DEPRECATED: use @setCellID0
-     */
-    void setCellID( int id) ;
 
     /** Sets the first cell id;
      */

--- a/src/cpp/include/IMPL/TPCHitImpl.h
+++ b/src/cpp/include/IMPL/TPCHitImpl.h
@@ -19,7 +19,13 @@ public:
   /** Default Constructor - initializes all data to 0's. 
    */
   TPCHitImpl() ;
-  
+
+  /// default copy constructor - use with care
+  TPCHitImpl(const TPCHitImpl&) = default ;
+
+  /// default assignment operator - use with care
+  TPCHitImpl& operator=(const TPCHitImpl&) = default ;
+
   /// Destructor.
   virtual ~TPCHitImpl() ;
   

--- a/src/cpp/include/IMPL/TrackImpl.h
+++ b/src/cpp/include/IMPL/TrackImpl.h
@@ -13,7 +13,6 @@
 
 typedef std::map< std::string , EVENT::IntVec* > IndexMap ; 
 
-//#define TRKNCOVMATRIX 15 // defined in TrackState
 
 namespace IMPL {
 
@@ -46,23 +45,12 @@ namespace IMPL {
     
     virtual int id() const { return simpleUID() ; }
 
-//     /** Type of track, i.e. the subdetector(s) used to derive the track paramters, e.g. "TPC", "COMB", etc.
-//      *  In order to save disc space working groups should try and define three to four letter acronyms for
-//      *  their tracking detectors.
-//      */
-//     virtual const std::string & getType() const ;
-
-
-
     /** Flagword that defines the type of track. Bits 0-15 can be used to denote the subdetectors
      *  that have contributed hits used in the track fit. The definition of the  hits has to be done 
      *  elsewhere, e.g. in the run header. Before LCIO 2.0 bit 31 was used to encode isReferencePointPCA (now deprecated).
      */
     virtual  int getType() const  ;
 
-//     /** Returns true if the corresponding bit in the type word is set.
-//      */
-//     virtual bool testType(int bitIndex) const ;
 
     /** Impact paramter of the track in (r-phi).
      *  Information is stored in the first TrackState of this Track, @see TrackState.
@@ -205,32 +193,20 @@ namespace IMPL {
 
     virtual void  setType( int  type ) ;
 
-    //    std::string _type ;
-    std::bitset<32> _type ;
+    std::bitset<32> _type{0} ;
 
-    
-    //float _d0 ;                       // stored in TrackState
-    //float _phi ;                      // stored in TrackState
-    //float _omega ;                    // stored in TrackState
-    //float _z0 ;                       // stored in TrackState
-    //float _tanLambda ;                // stored in TrackState
-    //EVENT::FloatVec _covMatrix ;      // stored in TrackState
-    //float  _reference[3] ;            // stored in TrackState
+   
+    float _chi2{0} ;
+    int   _ndf{0} ; 
+    float _dEdx{0} ;
+    float _dEdxError{0} ;
+    float _radiusOfInnermostHit{0} ;
+    EVENT::IntVec _subdetectorHitNumbers{} ;
 
+    EVENT::TrackVec _tracks{} ;
+    EVENT::TrackerHitVec _hits{} ;
 
-    //bool _isReferencePointPCA ;
-
-    float _chi2 ;
-    int   _ndf ; 
-    float _dEdx ;
-    float _dEdxError ;
-    float _radiusOfInnermostHit ;
-    EVENT::IntVec _subdetectorHitNumbers ;
-
-    EVENT::TrackVec _tracks ;
-    EVENT::TrackerHitVec _hits ;
-
-    EVENT::TrackStateVec _trackStates ;
+    EVENT::TrackStateVec _trackStates{} ;
 
 
 

--- a/src/cpp/include/IMPL/TrackStateImpl.h
+++ b/src/cpp/include/IMPL/TrackStateImpl.h
@@ -97,7 +97,7 @@ namespace IMPL {
 
   protected:
 
-    int _location ; // location defined by TrackStateLocationEnum
+    int _location{} ; // location defined by TrackStateLocationEnum
     float _d0 ;
     float _phi ;
     float _omega ;
@@ -105,7 +105,7 @@ namespace IMPL {
     float _tanLambda ;
 
     EVENT::FloatVec _covMatrix ;
-    float  _reference[TRKSTATENREFSIZE] ;
+    float  _reference[TRKSTATENREFSIZE]{} ;
 
 }; // class
 

--- a/src/cpp/include/IMPL/TrackerDataImpl.h
+++ b/src/cpp/include/IMPL/TrackerDataImpl.h
@@ -65,7 +65,7 @@ protected:
   int _cellID0 ;
   int _cellID1 ;
   float  _time ;
-  EVENT::FloatVec _charge ;
+  EVENT::FloatVec _charge{} ;
   
 }; // class
 } // namespace IMPL

--- a/src/cpp/include/IMPL/TrackerHitImpl.h
+++ b/src/cpp/include/IMPL/TrackerHitImpl.h
@@ -119,18 +119,17 @@ namespace IMPL {
 
 protected:
 
-    int _cellID0 ;
-    int _cellID1 ;
+    int _cellID0{0} ;
+    int _cellID1{0} ;
 
-    int _type ;
-    double _pos[3] ;
-    EVENT::FloatVec _cov ;
-    //float _dEdx ; // DEPRECATED. renamed to _EDep
-    float _EDep ;
-    float _EDepError ;
-    float _time ;
-    int _quality ;
-    EVENT::LCObjectVec _rawHits ;
+    int _type{0} ;
+    double _pos[3] = {0.,0.,0.} ;
+    EVENT::FloatVec _cov{} ;
+    float _EDep{0} ;
+    float _EDepError{0} ;
+    float _time{0} ;
+    int _quality{0} ;
+    EVENT::LCObjectVec _rawHits{} ;
     
 
 }; // class

--- a/src/cpp/include/IMPL/TrackerHitPlaneImpl.h
+++ b/src/cpp/include/IMPL/TrackerHitPlaneImpl.h
@@ -130,8 +130,6 @@ namespace IMPL {
     void setTime( float t ) ;
     void setQuality( int quality ) ;
     void setQualityBit( int bit , bool val=true ) ;
-    //void setCovMatrix( const EVENT::FloatVec& cov );
-    //void setCovMatrix( float cov[TRKHITPLANENCOVMATRIX]  );
 
 protected:
   
@@ -139,9 +137,9 @@ protected:
     int _cellID1 ;
 
     int    _type ;
-    double  _pos[3] ;
-    float  _u[2] ;
-    float  _v[2] ;
+    double  _pos[3] = {0,0,0};
+    float  _u[2] = {0,0};
+    float  _v[2] = {0,0};
     float  _du ;
     float  _dv ;
     float _EDep ;

--- a/src/cpp/include/IMPL/TrackerHitZCylinderImpl.h
+++ b/src/cpp/include/IMPL/TrackerHitZCylinderImpl.h
@@ -137,9 +137,8 @@ protected:
     int _cellID1 ;
 
     int _type ;
-    double _pos[3] ;
-    float  _center[2] ;
-    //float  _r;
+    double _pos[3] = {0,0,0} ;
+    float  _center[2]  = {0,0};
     float  _drphi ;
     float  _dz ;
     float _EDep ;

--- a/src/cpp/include/IMPL/TrackerPulseImpl.h
+++ b/src/cpp/include/IMPL/TrackerPulseImpl.h
@@ -22,6 +22,12 @@ namespace IMPL {
      */
     TrackerPulseImpl() ;
     
+    /// default copy constructor - use with care
+    TrackerPulseImpl(const TrackerPulseImpl&) = default ;
+
+    /// default assignment operator - use with care
+    TrackerPulseImpl& operator=(const TrackerPulseImpl&) = default ;
+
     /// Destructor.
     virtual ~TrackerPulseImpl() ;
     
@@ -88,9 +94,7 @@ protected:
     int _cellID0 ;
     int _cellID1 ;
     float _time ;
-    //float _timeError ;
     float _charge ;
-    //float _chargeError ;
     int   _quality ;
     EVENT::FloatVec _cov ;
     EVENT::TrackerData* _corrData ;

--- a/src/cpp/include/IMPL/TrackerRawDataImpl.h
+++ b/src/cpp/include/IMPL/TrackerRawDataImpl.h
@@ -66,7 +66,7 @@ protected:
   int _cellID1 ;
   int _channelID ;
   int  _time ;
-  EVENT::ShortVec _adc ;
+  EVENT::ShortVec _adc{} ;
   
 }; // class
 } // namespace IMPL

--- a/src/cpp/include/IMPL/VertexImpl.h
+++ b/src/cpp/include/IMPL/VertexImpl.h
@@ -94,7 +94,7 @@ namespace IMPL {
     std::string _type ;
     float _chi2 ;
     float _probability ;
-    float _vpos[3] ;
+    float _vpos[3] ={0,0,0} ;
     EVENT::FloatVec _cov ;
     EVENT::FloatVec _par ;
     EVENT::ReconstructedParticle* _aParticle ;

--- a/src/cpp/include/IMPL/VertexImpl.h
+++ b/src/cpp/include/IMPL/VertexImpl.h
@@ -26,6 +26,13 @@ namespace IMPL {
     /** Default constructor, initializes values to 0.
      */
     VertexImpl() ;
+
+    /// default copy constructor - use with care
+    VertexImpl(const VertexImpl&) = default ;
+
+    /// default assignment operator - use with care
+    VertexImpl& operator=(const VertexImpl&) = default ;
+
     
     // Destructor.
     virtual ~VertexImpl() ; 
@@ -84,7 +91,6 @@ namespace IMPL {
 
   protected:
     int _primary ;
-    //int _type ;
     std::string _type ;
     float _chi2 ;
     float _probability ;

--- a/src/cpp/include/LCRTRelations.h
+++ b/src/cpp/include/LCRTRelations.h
@@ -476,7 +476,7 @@ namespace lcrtrel{
 
 
 
-    ~LCRTRelations() {
+    virtual ~LCRTRelations() {
       for( PtrMap::iterator it = _map.begin() ; it != _map.end() ; ++it ){
 	cleaners()[ it->first ] ( it->second ) ;  // call the delete function
       }
@@ -543,8 +543,7 @@ namespace lcrtrel{
     } 
   
   
-    //   PtrVec* _vec ; 
-    mutable PtrMap _map ;
+    mutable PtrMap _map{} ;
   
   } ;
   

--- a/src/cpp/include/SIO/LCIORandomAccess.h
+++ b/src/cpp/include/SIO/LCIORandomAccess.h
@@ -67,15 +67,15 @@ namespace SIO{ // IO or IMPL ?
     void setFirstRecordLocation(long64 fl) { _firstRecordLocation = fl ; }
 
   protected:
-    RunEvent _minRunEvt ;
-    RunEvent _maxRunEvt ;
-    int  _nRunHeaders ;
-    int  _nEvents ;
-    int  _recordsAreInOrder ;  
-    long64  _indexLocation ;
-    long64  _prevLocation ;
-    long64  _nextLocation ;
-    long64  _firstRecordLocation ;
+    RunEvent _minRunEvt{} ;
+    RunEvent _maxRunEvt{} ;
+    int  _nRunHeaders{0} ;
+    int  _nEvents{0} ;
+    int  _recordsAreInOrder{0} ;  
+    long64  _indexLocation{0} ;
+    long64  _prevLocation{0} ;
+    long64  _nextLocation{0} ;
+    long64  _firstRecordLocation{0} ;
   }; // class
 
 

--- a/src/cpp/include/SIO/LCIORandomAccessMgr.h
+++ b/src/cpp/include/SIO/LCIORandomAccessMgr.h
@@ -45,6 +45,11 @@ namespace SIO {
 
     LCIORandomAccessMgr() ;
     
+    /// no copy constructor
+    LCIORandomAccessMgr(const LCIORandomAccessMgr&) = delete ;
+    /// no default assignment operator 
+    LCIORandomAccessMgr& operator=(const LCIORandomAccessMgr&) = delete ;
+
     virtual ~LCIORandomAccessMgr() ;
  
     /** Return the position of the specified Event record or Run record respectively (if EventNum == -1 ).

--- a/src/cpp/include/SIO/LCIORandomAccessMgr.h
+++ b/src/cpp/include/SIO/LCIORandomAccessMgr.h
@@ -120,10 +120,10 @@ namespace SIO {
     } 
 
     // ----- map with RunHeader and EventHeader record positions
-    RunEventMap _runEvtMap ;
+    RunEventMap _runEvtMap{} ;
     
     // ----- list of LCIORandomAccess objects 
-    std::list< LCIORandomAccess* > _list ;
+    std::list< LCIORandomAccess* > _list{} ;
 
     LCIORandomAccess* _fileRecord ;
 

--- a/src/cpp/include/SIO/RunEventMap.h
+++ b/src/cpp/include/SIO/RunEventMap.h
@@ -78,10 +78,10 @@ namespace SIO {
 
   protected: 
 
-    MapType _map ;
+    MapType _map{} ;
 
-    int _nRun ;
-    int _nEvt ;
+    int _nRun{0} ;
+    int _nEvt{0} ;
 
   }; // class
  } // namespace

--- a/src/cpp/include/SIO/SIOCollectionHandler.h
+++ b/src/cpp/include/SIO/SIOCollectionHandler.h
@@ -26,6 +26,11 @@ namespace SIO {
     
   public:
     
+    /// default copy constructor - use with care
+    SIOCollectionHandler(const SIOCollectionHandler&) = default ;
+    /// default assignment operator - use with care
+    SIOCollectionHandler& operator=(const SIOCollectionHandler&) = default ;
+
     /** The default constructor needs the name, the type and a pointer 
      * the address of the collection. Throws an exception if handler
      * for given type doesn't exist.
@@ -53,7 +58,7 @@ namespace SIO {
     const EVENT::LCCollection *_col ;   // for writing we use the data interface
     
     std::string _myType ;
-    SIOObjectHandler* _myHandler  ;
+    SIOObjectHandler* _myHandler{NULL}  ;
     
   }; // class
   

--- a/src/cpp/include/SIO/SIOCollectionHandler.h
+++ b/src/cpp/include/SIO/SIOCollectionHandler.h
@@ -26,10 +26,8 @@ namespace SIO {
     
   public:
     
-    /// default copy constructor - use with care
-    SIOCollectionHandler(const SIOCollectionHandler&) = default ;
-    /// default assignment operator - use with care
-    SIOCollectionHandler& operator=(const SIOCollectionHandler&) = default ;
+    SIOCollectionHandler(const SIOCollectionHandler&) = delete;
+    SIOCollectionHandler& operator=(const SIOCollectionHandler&) = delete ;
 
     /** The default constructor needs the name, the type and a pointer 
      * the address of the collection. Throws an exception if handler

--- a/src/cpp/include/SIO/SIOEventHandler.h
+++ b/src/cpp/include/SIO/SIOEventHandler.h
@@ -41,11 +41,11 @@ namespace SIO {
 
   private: 
     // event implementation for reading 
-    IOIMPL::LCEventIOImpl **_evtP ;  
+    IOIMPL::LCEventIOImpl **_evtP{NULL} ;  
     // event data interface for writing
-    const EVENT::LCEvent *_evt ;  
+    const EVENT::LCEvent *_evt{NULL} ;  
     
-    std::set< std::string > _colSubSet ;
+    std::set< std::string > _colSubSet{} ;
 
   }; // class
   

--- a/src/cpp/include/SIO/SIOEventHandler.h
+++ b/src/cpp/include/SIO/SIOEventHandler.h
@@ -23,6 +23,9 @@ namespace SIO {
 
   public:
     
+    SIOEventHandler(const SIOEventHandler&) = delete;
+    SIOEventHandler& operator=(const SIOEventHandler&) = delete ;
+
     SIOEventHandler(const std::string& name) ;
     SIOEventHandler(const std::string& name, IOIMPL::LCEventIOImpl** evtP) ;
     virtual ~SIOEventHandler() ;

--- a/src/cpp/include/SIO/SIOHandlerMgr.h
+++ b/src/cpp/include/SIO/SIOHandlerMgr.h
@@ -42,7 +42,7 @@ namespace SIO {
     
   private:
     
-    SIOHandlerMap _map ;
+    SIOHandlerMap _map{} ;
     
     static SIOHandlerMgr* _me ;
     

--- a/src/cpp/include/SIO/SIOIndexHandler.h
+++ b/src/cpp/include/SIO/SIOIndexHandler.h
@@ -20,6 +20,9 @@ namespace SIO {
 
   public:
     
+    SIOIndexHandler(const SIOIndexHandler&) = delete;
+    SIOIndexHandler& operator=(const SIOIndexHandler&) = delete ;
+
     /** C'tor.
      */
     SIOIndexHandler(const std::string& name, LCIORandomAccessMgr* raMgr) ; 
@@ -31,15 +34,9 @@ namespace SIO {
     virtual unsigned int   xfer( SIO_stream*, SIO_operation, unsigned int ) ;
     virtual unsigned int   version() ;
     
-//     void setWritePtr(const LCIORandomAccess* ra ) ; 
-//     void setReadPtr( LCIORandomAccess** raP ) ; 
-    
   private: 
-//     LCIORandomAccess** _raP ;  // address for reading
-//     const LCIORandomAccess* _ra ;  // object for writing
 
-//     RunEventMap* _reMap ;
-    LCIORandomAccessMgr* _raMgr ;
+    LCIORandomAccessMgr* _raMgr{NULL} ;
 
   }; // class
   

--- a/src/cpp/include/SIO/SIOLCGenericObjectHandler.h
+++ b/src/cpp/include/SIO/SIOLCGenericObjectHandler.h
@@ -34,10 +34,10 @@ namespace SIO {
 
 
   protected:
-    int _nInt ;
-    int _nFloat ;
-    int _nDouble ;
-    bool _isFixedSize ;
+    int _nInt{0} ;
+    int _nFloat{0} ;
+    int _nDouble{0} ;
+    bool _isFixedSize{false} ;
 
   }; // class
     

--- a/src/cpp/include/SIO/SIOObjectHandler.h
+++ b/src/cpp/include/SIO/SIOObjectHandler.h
@@ -57,8 +57,8 @@ public:
  protected:
 
 
-  unsigned int _flag ; 
-  unsigned int _vers ;
+  unsigned int _flag{0} ; 
+  unsigned int _vers{0} ;
   
 }; // class
 

--- a/src/cpp/include/SIO/SIORandomAccessHandler.h
+++ b/src/cpp/include/SIO/SIORandomAccessHandler.h
@@ -20,6 +20,9 @@ namespace SIO {
 
   public:
     
+    SIORandomAccessHandler(const SIORandomAccessHandler&) = delete;
+    SIORandomAccessHandler& operator=(const SIORandomAccessHandler&) = delete ;
+
     /** C'tor.
      */
     SIORandomAccessHandler(const std::string& name, LCIORandomAccessMgr* raMgr) ; 
@@ -31,15 +34,9 @@ namespace SIO {
     virtual unsigned int   xfer( SIO_stream*, SIO_operation, unsigned int ) ;
     virtual unsigned int   version() ;
     
-//     void setWritePtr(const LCIORandomAccess* ra ) ; 
-//     void setReadPtr( LCIORandomAccess** raP ) ; 
-    
   private: 
-//     LCIORandomAccess** _raP ;  // address for reading
-//     const LCIORandomAccess* _ra ;  // object for writing
 
-//     RunEventMap* _reMap ;
-    LCIORandomAccessMgr* _raMgr ;
+    LCIORandomAccessMgr* _raMgr{NULL} ;
 
   }; // class
   

--- a/src/cpp/include/SIO/SIOReader.h
+++ b/src/cpp/include/SIO/SIOReader.h
@@ -228,33 +228,27 @@ class SIOEventHandler ;
 
   protected:
     
-    // we need an SIO record for every type
-//     SIO_record *_evtRecord ;
-//     SIO_record *_hdrRecord ;
-//     SIO_record *_runRecord ;
-    SIO_record *_dummyRecord ;  // used for reading arbitrary records
-    SIO_stream *_stream ;
+    SIO_record *_dummyRecord {NULL};  // used for reading arbitrary records
+    SIO_stream *_stream{NULL} ;
 
-    SIORunHeaderHandler* _runHandler ;
-    SIOEventHandler* _evtHandler ;
+    SIORunHeaderHandler* _runHandler{NULL} ;
+    SIOEventHandler* _evtHandler{NULL} ;
 
   private:
     
-    IOIMPL::LCEventIOImpl *_defaultEvt ; // used to add collections when reading 
-    IOIMPL::LCEventIOImpl *_evt ;
-    IOIMPL::LCRunHeaderIOImpl *_run ;
+    IOIMPL::LCEventIOImpl *_defaultEvt{NULL} ; // used to add collections when reading 
+    IOIMPL::LCEventIOImpl *_evt{NULL} ;
+    IOIMPL::LCRunHeaderIOImpl *_run{NULL} ;
 
-    std::set<IO::LCRunListener*> _runListeners ;
-    std::set<IO::LCEventListener*> _evtListeners ;
+    std::set<IO::LCRunListener*> _runListeners{} ;
+    std::set<IO::LCEventListener*> _evtListeners{} ;
     
-    std::vector<std::string> _myFilenames ;
-    unsigned int _currentFileIndex ;
+    std::vector<std::string> _myFilenames{} ;
+    unsigned int _currentFileIndex{0} ;
 
-    //    EventMap _evtMap ;
-    bool _readEventMap ;
+    bool _readEventMap{false} ;
     
-    //    RunEventMap _reMap ;
-    LCIORandomAccessMgr _raMgr ;
+    LCIORandomAccessMgr _raMgr{} ;
 
   }; // class
 } // namespace

--- a/src/cpp/include/SIO/SIOReader.h
+++ b/src/cpp/include/SIO/SIOReader.h
@@ -40,8 +40,12 @@ class SIOEventHandler ;
      */
     SIOReader( int lcReaderFlag=0 ) ;
     
-    // Destructor
+    /// no copy constructor
+    SIOReader(const SIOReader&) = delete ;
+    /// no assignment operator
+    SIOReader& operator=(const SIOReader&) = delete ;
 
+    /// Destructor
     virtual ~SIOReader() ;
     
 

--- a/src/cpp/include/SIO/SIORunHeaderHandler.h
+++ b/src/cpp/include/SIO/SIORunHeaderHandler.h
@@ -24,6 +24,9 @@ namespace SIO {
 
   public:
     
+    SIORunHeaderHandler(const SIORunHeaderHandler&) = delete;
+    SIORunHeaderHandler& operator=(const SIORunHeaderHandler&) = delete ;
+
     /** C'tor for writing
      */
     SIORunHeaderHandler(const std::string& name) ;
@@ -40,8 +43,8 @@ namespace SIO {
     void setRunHeaderPtr(IOIMPL::LCRunHeaderIOImpl** hdrP ) ; 
     
   private: 
-    IOIMPL::LCRunHeaderIOImpl** _rhP ;  // address for reading
-    const EVENT::LCRunHeader* _hdr ;  // runheader for writing
+    IOIMPL::LCRunHeaderIOImpl** _rhP{NULL} ;  // address for reading
+    const EVENT::LCRunHeader* _hdr{NULL} ;  // runheader for writing
     
   }; // class
   

--- a/src/cpp/include/SIO/SIOVertexHandler.h
+++ b/src/cpp/include/SIO/SIOVertexHandler.h
@@ -38,10 +38,9 @@ namespace SIO {
     virtual unsigned int write(SIO_stream* stream, const EVENT::LCObject* obj) ;
 
   protected:
-    std::map<int,std::string> imr; //indexmap for reading
-    //std::map<std::string,int> imw; //indexmap for writing (used with FIFO)
-    std::set<std::string> _set;
-    EVENT::StringVec parameters; //needed for putting the collection parameters into the STL Containers
+    std::map<int,std::string> imr{}; //indexmap for reading
+    std::set<std::string> _set{};
+    EVENT::StringVec parameters{}; //needed for putting the collection parameters into the STL Containers
     
   }; // class
 } // namespace

--- a/src/cpp/include/SIO/SIOWriter.h
+++ b/src/cpp/include/SIO/SIOWriter.h
@@ -42,6 +42,12 @@ namespace SIO {
     /**Default constructor.
      */
     SIOWriter() ;
+
+    /// no copy constructor
+    SIOWriter(const SIOWriter&) = delete ;
+    /// no assignment operator
+    SIOWriter& operator=(const SIOWriter&) = delete ;
+
     /**
      * Destructor
      */

--- a/src/cpp/include/SIO/SIOWriter.h
+++ b/src/cpp/include/SIO/SIOWriter.h
@@ -130,15 +130,11 @@ namespace SIO {
 
     SIOEventHandler *_hdrHandler ;
     SIORunHeaderHandler *_runHandler ;
-    std::vector<SIO_block*> _connectedBlocks ;
+    std::vector<SIO_block*> _connectedBlocks{} ;
 
   protected:
     
-//     SIO_record *_evtRecord ;
-//     SIO_record *_hdrRecord ;
-//     SIO_record *_runRecord ;
-
-    LCIORandomAccessMgr _raMgr ;
+    LCIORandomAccessMgr _raMgr{} ;
 
   }; // class
 

--- a/src/cpp/include/UTIL/BitField64.h
+++ b/src/cpp/include/UTIL/BitField64.h
@@ -103,14 +103,14 @@ namespace UTIL {
 
   protected:
   
-    lcio::long64& _b ;
-    lcio::ulong64 _mask ;
+    lcio::long64& _b  ;
+    lcio::ulong64 _mask{0} ;
     std::string _name ;
-    unsigned _offset ;
-    unsigned _width ;
-    int _minVal ;
-    int _maxVal ;
-    bool _isSigned ;
+    unsigned _offset{0} ;
+    unsigned _width{0} ;
+    int _minVal{0} ;
+    int _maxVal{0} ;
+    bool _isSigned{false} ;
 
   };
 
@@ -246,9 +246,9 @@ namespace UTIL {
 
     // -------------- data members:--------------
 
-    std::vector<BitFieldValue*>  _fields ;
+    std::vector<BitFieldValue*>  _fields{} ;
     lcio::long64 _value ;
-    IndexMap _map ;
+    IndexMap _map{} ;
     lcio::long64 _joined ;
 
 

--- a/src/cpp/include/UTIL/CellIDDecoder.h
+++ b/src/cpp/include/UTIL/CellIDDecoder.h
@@ -31,7 +31,7 @@ namespace UTIL{
     
   public:  
 
-    CellIDDecoder() = delete ;
+    CellIDDecoder() = default ;
     CellIDDecoder(const CellIDDecoder& ) = delete ;
     CellIDDecoder& operator=(const CellIDDecoder& ) = delete ;
     

--- a/src/cpp/include/UTIL/CellIDDecoder.h
+++ b/src/cpp/include/UTIL/CellIDDecoder.h
@@ -31,6 +31,11 @@ namespace UTIL{
     
   public:  
 
+    CellIDDecoder() = delete ;
+    CellIDDecoder(const CellIDDecoder& ) = delete ;
+    CellIDDecoder& operator=(const CellIDDecoder& ) = delete ;
+    
+
     /** Constructor takes encoding string as argument.
      */
   CellIDDecoder( const std::string& encoder_str ) : _oldHit(0) {
@@ -105,8 +110,8 @@ namespace UTIL{
     }
     
   protected:
-    BitField64* _b ;
-    const T* _oldHit ;
+    BitField64* _b{} ;
+    const T* _oldHit{NULL} ;
     
     static std::string*  _defaultEncoding ;
   } ; 
@@ -116,30 +121,6 @@ namespace UTIL{
   = new std::string("byte0:8,byte1:8,byte2:8,byte3:8,byte4:8,byte5:8,byte6:8,byte7:8") ;
 
   
-
-//  /** Provides access to the bit fields, e.g. <br>
-//   *   int layer =  myCellIDEncoding( hit )[ "layer" ] ;
-//   * Specialization for SimTrackerHits that have only one cellID.
-//   */
-//  template<>
-//  inline const BitField64 & CellIDDecoder<SimTrackerHit>::operator()(const SimTrackerHit* hit ){  
-//    
-//    if( hit != _oldHit && hit ) {
-//      
-//      long64 val = long64( hit->getCellID() & 0xffffffff )  ;
-//      
-//      _b->setValue( val ) ;
-//      
-//      _oldHit = hit ;
-//    }
-//    
-//    return  *_b ;
-//  }
-//  
-//  
-//  template <>
-//  std::string* CellIDDecoder<SimTrackerHit>::_defaultEncoding  ;
-
 } // namespace
 #endif
 

--- a/src/cpp/include/UTIL/CellIDEncoder.h
+++ b/src/cpp/include/UTIL/CellIDEncoder.h
@@ -100,7 +100,10 @@ namespace UTIL{
   class CellIDEncoder : public BitField64 {
 
   public:  
-    
+   
+    CellIDEncoder( const CellIDEncoder&) = delete ;
+    CellIDEncoder& operator=(const CellIDEncoder&) = delete ;
+
     /** Constructor, sets collection parameter LCIO::CellIDEncoding to the given encoding string.
      */
     CellIDEncoder( const std::string& cellIDEncoding ,  EVENT::LCCollection* col) :

--- a/src/cpp/include/UTIL/CollectionParameterMap.h
+++ b/src/cpp/include/UTIL/CollectionParameterMap.h
@@ -26,7 +26,7 @@ namespace UTIL{
   class CollectionParameterMap {
 
   public:  
-    CollectionParameterMap() = delete ;
+    CollectionParameterMap() = default ;
     CollectionParameterMap(const CollectionParameterMap& ) = delete ;
     CollectionParameterMap& operator=(const CollectionParameterMap& ) = delete ;
     
@@ -56,10 +56,10 @@ namespace UTIL{
     
     void init( const LCCollection* col ) ; 
  
-    std::string _keyName ;
-    std::string _valueName ;
-    LCCollection* _col ;
-    map_type _map ;
+    std::string _keyName{} ;
+    std::string _valueName{} ;
+    LCCollection* _col{NULL} ;
+    map_type _map{} ;
 
 
   } ; 

--- a/src/cpp/include/UTIL/CollectionParameterMap.h
+++ b/src/cpp/include/UTIL/CollectionParameterMap.h
@@ -26,6 +26,9 @@ namespace UTIL{
   class CollectionParameterMap {
 
   public:  
+    CollectionParameterMap() = delete ;
+    CollectionParameterMap(const CollectionParameterMap& ) = delete ;
+    CollectionParameterMap& operator=(const CollectionParameterMap& ) = delete ;
     
     typedef  std::map< std::string, int >  map_type ;
 
@@ -50,7 +53,6 @@ namespace UTIL{
 
   protected:
 
-    CollectionParameterMap();
     
     void init( const LCCollection* col ) ; 
  

--- a/src/cpp/include/UTIL/IndexMap.h
+++ b/src/cpp/include/UTIL/IndexMap.h
@@ -10,7 +10,7 @@
 
 namespace UTIL{
   
-/** utility class to manage indexes according to Collection Parameters
+/** utility class to manage indices according to Collection Parameters
  * 
  *  EXP: UNDER DEVELOPMENT!!! - Don't use this class yet
  *
@@ -57,6 +57,11 @@ namespace UTIL{
      */
     IndexMap(const EVENT::LCCollection* col, const std::string& key1, const std::string& key2);
 
+    /// no copy constructor
+    IndexMap(const IndexMap&) = delete ;
+    /// no assignment operator
+    IndexMap& operator=(const IndexMap&) = delete ;
+
     //destructor
     ~IndexMap();
 
@@ -70,8 +75,8 @@ namespace UTIL{
     const EVENT::LCCollection* _col;
     const std::string _key1;
     const std::string _key2;
-    EVENT::StringVec _strvec;
-    EVENT::IntVec _intvec;
+    EVENT::StringVec _strvec{};
+    EVENT::IntVec _intvec{};
   }; // class
 
 }//namespace

--- a/src/cpp/include/UTIL/LCFixedObject.h
+++ b/src/cpp/include/UTIL/LCFixedObject.h
@@ -41,16 +41,16 @@ namespace UTIL{
      * 
      * 
      */
-    LCFixedObject(LCObject* obj) : 
+    LCFixedObject(LCObject* object) : 
       _createdObject(false)  {
       
-      _obj = dynamic_cast<LCGenericObjectImpl*>( obj )  ;
+      _obj = dynamic_cast<LCGenericObjectImpl*>( object )  ;
       
       if( _obj==0 ){
 
 	// could be an instance of LCFixedObject !?
 	LCFixedObject<NINT,NFLOAT,NDOUBLE>* f = 
-	  dynamic_cast< LCFixedObject<NINT,NFLOAT,NDOUBLE>* >( obj ) ;
+	  dynamic_cast< LCFixedObject<NINT,NFLOAT,NDOUBLE>* >( object ) ;
 
 	if( f != 0 )
 	  _obj = f->obj() ;

--- a/src/cpp/include/UTIL/LCFixedObject.h
+++ b/src/cpp/include/UTIL/LCFixedObject.h
@@ -28,6 +28,12 @@ namespace UTIL{
     
   public: 
     
+    /// default copy constructor - use with care
+    LCFixedObject(const LCFixedObject&) = default ;
+
+    /// default assignment operator - use with care
+    LCFixedObject& operator=(const LCFixedObject&) = default ;
+
     /** Default c'tor.
      */
     LCFixedObject():
@@ -108,8 +114,8 @@ namespace UTIL{
     
   protected:
     
-    LCGenericObjectImpl* _obj ;
-    bool _createdObject ;
+    LCGenericObjectImpl* _obj{NULL} ;
+    bool _createdObject{false} ;
     
   }; 
   

--- a/src/cpp/include/UTIL/LCIterator.h
+++ b/src/cpp/include/UTIL/LCIterator.h
@@ -47,9 +47,8 @@ namespace UTIL {
      *  this will behave the same as an empty collection - use operator() to
      *  test, if the collection exists.
      */
-    LCIterator<T>( EVENT::LCEvent* evt, const std::string& name ) : _i(0) {
+    LCIterator<T>( EVENT::LCEvent* evt, const std::string& name ) : _i(0), _col(0) {
     
-      _col = 0 ;
     
       try{
       
@@ -117,7 +116,7 @@ namespace UTIL {
     EVENT::LCCollection* operator()() { return _col ; }
 
   private:
-    int _n, _i ;
+    int _n{0}, _i ;
     EVENT::LCCollection* _col ;
   } ;
 

--- a/src/cpp/include/UTIL/LCObjectHandle.h
+++ b/src/cpp/include/UTIL/LCObjectHandle.h
@@ -20,12 +20,12 @@ namespace UTIL{
   public: 
     virtual ~LCObjectHandle() { /*no_op*/; } 
     
-    LCObjectHandle( T* lcObj) : _lcObj(lcObj) {
+    LCObjectHandle( T* obj) : _lcObj(obj) {
     }
 
-    LCObjectHandle(EVENT::LCObject* lcObj){
+    LCObjectHandle(EVENT::LCObject* obj){
       
-      _lcObj = dynamic_cast< T* >( lcObj ) ;
+      _lcObj = dynamic_cast< T* >( obj ) ;
 
       if( _lcObj == 0 )
 	throw EVENT::Exception("dynamic cast failed for LCObjectHandle() !" ) ;

--- a/src/cpp/include/UTIL/LCRelationNavigator.h
+++ b/src/cpp/include/UTIL/LCRelationNavigator.h
@@ -91,8 +91,8 @@ namespace UTIL {
     void removeRelation(EVENT::LCObject * from, EVENT::LCObject * to, RelMap& map ) ;
     void addRelation(EVENT::LCObject * from, EVENT::LCObject * to, float weight, RelMap& map) ;
 
-    mutable RelMap _map ;
-    mutable RelMap _rMap ;
+    mutable RelMap _map{} ;
+    mutable RelMap _rMap{} ;
     std::string _from ;
     std::string _to ;
     

--- a/src/cpp/include/UTIL/LCSplitWriter.h
+++ b/src/cpp/include/UTIL/LCSplitWriter.h
@@ -35,6 +35,11 @@ namespace UTIL{
       _lastCount(4294967295UL) {    
     }    
    
+    /// no copy constructor
+    LCSplitWriter(const LCSplitWriter&) = delete ;
+    /// no assignment operator
+    LCSplitWriter& operator=(const LCSplitWriter&) = delete ;
+
     /** Destructor.
      */
     virtual ~LCSplitWriter() {;}

--- a/src/cpp/include/UTIL/LCStdHepRdr.h
+++ b/src/cpp/include/UTIL/LCStdHepRdr.h
@@ -25,18 +25,23 @@ namespace UTIL{
     
   public:
 
-	/** Open the stdhep input file in the constructer
-	 */
+    /** Open the stdhep input file in the constructer
+     */
     LCStdHepRdr(const char* evfile) ;
 
-	/** noop
-	 */
-	~LCStdHepRdr() ;
+    /// no copy constructor
+    LCStdHepRdr(const LCStdHepRdr&) = delete ;
+    /// no assignment operator
+    LCStdHepRdr& operator=(const LCStdHepRdr&) = delete ;
 
+    /** noop
+     */
+    ~LCStdHepRdr() ;
 
-	/** Get number of events in the stdhep file.
+    
+    /** Get number of events in the stdhep file.
      *  This number is read from the file header (no guarantee that it is correct)
-    */
+     */
     long getNumberOfEvents() const {
       return _reader->numEvents() ;
     }
@@ -72,7 +77,7 @@ namespace UTIL{
 
   private:
     
-	lStdHep* _reader;
+    lStdHep* _reader{NULL};
     
 
   }; // class

--- a/src/cpp/include/UTIL/LCStdHepRdrNew.h
+++ b/src/cpp/include/UTIL/LCStdHepRdrNew.h
@@ -29,6 +29,11 @@ namespace UTIL{
 	 */
     LCStdHepRdrNew(const char* evfile) ;
 
+    /// no copy constructor
+    LCStdHepRdrNew(const LCStdHepRdrNew&) = delete ;
+    /// no assignment operator
+    LCStdHepRdrNew& operator=(const LCStdHepRdrNew&) = delete ;
+
 	/** noop
 	 */
 	~LCStdHepRdrNew() ;
@@ -76,8 +81,8 @@ namespace UTIL{
 
   private:
     
-	lStdHep* _reader;
-	bool _writeEventNumber;
+    lStdHep* _reader{};
+    bool _writeEventNumber{false};
     
 
   }; // class

--- a/src/cpp/include/UTIL/LCTime.h
+++ b/src/cpp/include/UTIL/LCTime.h
@@ -22,13 +22,13 @@ namespace UTIL {
     /** Helper struct that holds the calendar time.
      */
     struct CalendarTime{
-      short year  ;
-      short  month ;
-      short  day   ;
-      short  hour ;
-      short  min ;
-      short  sec ;
-      int ns ;
+      short year{0}  ;
+      short  month{0} ;
+      short  day{0}   ;
+      short  hour{0} ;
+      short  min{0} ;
+      short  sec{0} ;
+      int ns{0} ;
     } ;
 
   public: 
@@ -63,13 +63,13 @@ namespace UTIL {
      *  year is multiple of 4 and not multiple of 100<br>
      *  or year is multiple of 400.
      */
-    bool isLeapYear( int year ) const { return ( ( !( year % 4 ) &&  ( year%100 ) ) || !(year%400)   ) ; }
+    bool isLeapYear( int y ) const { return ( ( !( y % 4 ) &&  ( y%100 ) ) || !(y%400)   ) ; }
 
     /** The number if days in the given year in the Gregorian calendar. */
-    int daysInYear( int year ) const ;
+    int daysInYear( int y ) const ;
 
     /** The number if days in the given month and year in the Gregorian calendar. */
-    int daysInMonth( int month , int year )  const ;
+    int daysInMonth( int m , int y )  const ;
 
     /** Date in human readable format, e.g. 10.02.2005  10:54:29.123456789 :<br>
      *  dd.mm.yyyy  hh:mm:ss._ms_us_ns
@@ -116,8 +116,8 @@ namespace UTIL {
     
   protected: 
     
-    EVENT::long64 _t ;  // time stamp in ns
-    CalendarTime  _d ;  // calendar date and time
+    EVENT::long64 _t{0} ;  // time stamp in ns
+    CalendarTime  _d{} ;  // calendar date and time
     
     
     // internal helper methods

--- a/src/cpp/include/UTIL/LCTrackerConf.h
+++ b/src/cpp/include/UTIL/LCTrackerConf.h
@@ -74,17 +74,17 @@ namespace UTIL {
     }
     
     /// set the encoding string. Throws exception if it was already accessed to prevent inconsistencies
-    void set_encoding_string( const std::string& encoding_string ) {
+    void set_encoding_string( const std::string& encodingString ) {
       if( _accessed ) throw std::logic_error( "The encoding string was already accessed! Changing it now will lead to inconsistencies! Fix your code!" );
 
       bool isValid = true ;
 
-      unsigned long long subdetPos = encoding_string.find( "subdet" );
-      unsigned long long systemPos = encoding_string.find( "system" );
-      unsigned long long sidePos   = encoding_string.find( "side" ) ;
-      unsigned long long layerPos  = encoding_string.find( "layer" ) ;
-      unsigned long long modulePos = encoding_string.find( "module" ) ;
-      unsigned long long sensorPos = encoding_string.find( "sensor" ) ;
+      unsigned long long subdetPos = encodingString.find( "subdet" );
+      unsigned long long systemPos = encodingString.find( "system" );
+      unsigned long long sidePos   = encodingString.find( "side" ) ;
+      unsigned long long layerPos  = encodingString.find( "layer" ) ;
+      unsigned long long modulePos = encodingString.find( "module" ) ;
+      unsigned long long sensorPos = encodingString.find( "sensor" ) ;
 
       isValid = ( (subdetPos  != std::string::npos || systemPos != std::string::npos) &&
 		  sidePos    != std::string::npos &&
@@ -102,7 +102,7 @@ namespace UTIL {
       if( ! isValid ) throw std::runtime_error(" LCTrackerCellID::set_encoding_string(): string needs to contain"
 					       " \"subdet:A,side:B,layer:C,module:D,sensor:E\" " ) ;
 
-      _encoding = encoding_string;
+      _encoding = encodingString;
     }
     
     /// set accessed to true

--- a/src/cpp/include/UTIL/LCTypedVector.h
+++ b/src/cpp/include/UTIL/LCTypedVector.h
@@ -29,20 +29,23 @@ namespace UTIL{
   class LCTypedVector : public  std::vector<T*> {
     
   public:  
-    
-    LCTypedVector( EVENT::LCCollection* col ) : _col( col) {
+    LCTypedVector() = default ;
+    LCTypedVector(const LCTypedVector& ) = delete ;
+    LCTypedVector& operator=(const LCTypedVector& ) = delete ;
+  
+    LCTypedVector( EVENT::LCCollection* collection ) : _col( collection) {
       
       this->resize( _col->getNumberOfElements() ) ;
       
       for(int i=0;i<_col->getNumberOfElements();i++ ) {
 	
-	(*this)[i] = dynamic_cast<T*>( col->getElementAt(i) ) ;
+	(*this)[i] = dynamic_cast<T*>( _col->getElementAt(i) ) ;
 	
 	// check the first element for the proper type
 	if( i == 0 && (*this)[i] == 0  ){
 
 	  std::stringstream str ;
-	  str << "LCTypedVector: cannot convert " << col->getTypeName() << " to " 
+	  str << "LCTypedVector: cannot convert " << _col->getTypeName() << " to " 
 	      << typeid(T).name()  ;
 
 	  throw EVENT::Exception(  str.str().c_str() ) ; 

--- a/src/cpp/include/UTIL/LCWarning.h
+++ b/src/cpp/include/UTIL/LCWarning.h
@@ -43,13 +43,13 @@ private:
 
 
     struct _warning_cfg_struct{
-        std::string txt;
-        int max;
-        int counter;
+      std::string txt{};
+      int max{0};
+      int counter{0};
     };
 
-    std::map< std::string, _warning_cfg_struct > _warning_cfg ; // warning configurations
-    std::map< std::string, _warning_cfg_struct > :: iterator _warning_cfg_it ; // iterator
+    std::map< std::string, _warning_cfg_struct > _warning_cfg{} ; // warning configurations
+    std::map< std::string, _warning_cfg_struct >::iterator _warning_cfg_it{} ; // iterator
     std::ostream& _outstream ; // where warnings get printed
 
 }; // class

--- a/src/cpp/include/UTIL/Operators.h
+++ b/src/cpp/include/UTIL/Operators.h
@@ -159,7 +159,7 @@ namespace UTIL{
   template <class T>
   class LCIO_LONG{
         public:
-            LCIO_LONG() = delete ;
+            LCIO_LONG() = default ;
             LCIO_LONG(const LCIO_LONG& ) = default ;
             LCIO_LONG& operator=(const LCIO_LONG& ) = default ;
             LCIO_LONG(const T& o, const EVENT::LCCollection* c){ obj=&o; col=c;};

--- a/src/cpp/include/UTIL/Operators.h
+++ b/src/cpp/include/UTIL/Operators.h
@@ -159,13 +159,15 @@ namespace UTIL{
   template <class T>
   class LCIO_LONG{
         public:
-            //lcio_long(const T& o, EVENT::LCCollection* c);
+            LCIO_LONG() = delete ;
+            LCIO_LONG(const LCIO_LONG& ) = default ;
+            LCIO_LONG& operator=(const LCIO_LONG& ) = default ;
             LCIO_LONG(const T& o, const EVENT::LCCollection* c){ obj=&o; col=c;};
             const T *object(void) const {return(obj);};
             const EVENT::LCCollection *collection(void) const {return(col);};
         private: 
-            const T *obj;
-            const EVENT::LCCollection *col;
+            const T *obj{NULL};
+            const EVENT::LCCollection *col{NULL};
   };
 
   //test:

--- a/src/cpp/include/UTIL/PIDHandler.h
+++ b/src/cpp/include/UTIL/PIDHandler.h
@@ -41,7 +41,7 @@ namespace UTIL{
 
 
   public:  
-    PIDHandler() = delete ;
+    PIDHandler() = default ;
     PIDHandler(const PIDHandler& ) = delete ;
     PIDHandler& operator=(const PIDHandler& ) = delete ;
     
@@ -122,13 +122,13 @@ namespace UTIL{
     void init( const LCCollection* col ) ;
 
 
-    LCCollection* _col ;
-    CPM _cpm ;
-    int _type ; 
-    int _maxID ;
-    PNM _pNames ; 
-    CPMINV _cpmInv ;
-    IntVec _ids ;
+    LCCollection* _col{NULL} ;
+    CPM _cpm{} ;
+    int _type{0} ; 
+    int _maxID{0} ;
+    PNM _pNames{} ; 
+    CPMINV _cpmInv{} ;
+    IntVec _ids{} ;
 
   } ; 
   

--- a/src/cpp/include/UTIL/PIDHandler.h
+++ b/src/cpp/include/UTIL/PIDHandler.h
@@ -41,6 +41,9 @@ namespace UTIL{
 
 
   public:  
+    PIDHandler() = delete ;
+    PIDHandler(const PIDHandler& ) = delete ;
+    PIDHandler& operator=(const PIDHandler& ) = delete ;
     
     /** Create PIDHandler for reading from the given collection - read the collection parameters
      *  PIDAlgorithmTypeName, PIDAlgorithmTypeID and the corresponding 
@@ -118,8 +121,7 @@ namespace UTIL{
     int nextID() { return ++_maxID ; }
     void init( const LCCollection* col ) ;
 
-    PIDHandler();
- 
+
     LCCollection* _col ;
     CPM _cpm ;
     int _type ; 

--- a/src/cpp/include/UTIL/lStdHep.hh
+++ b/src/cpp/include/UTIL/lStdHep.hh
@@ -322,7 +322,7 @@ private:
       long *trigMasks;
       long *ptrEvents;
    };
-   EventTable     eventTable;
+  EventTable     eventTable{};
 //
 // The event
 //
@@ -403,7 +403,7 @@ private:
       double  estdseed1;
       double  estdseed2;
    };
-   Event          event;
+  Event          event{};
 };
 
 } // end namespace

--- a/src/cpp/include/UTIL/lStdHep.hh
+++ b/src/cpp/include/UTIL/lStdHep.hh
@@ -285,7 +285,11 @@ private:
 //
    class EventTable {
    public:
-      EventTable();
+       EventTable();
+      /// no copy constructor
+      EventTable(const EventTable&) = delete ;
+      /// no assignment operator
+      EventTable& operator=(const EventTable&) = delete ;
       ~EventTable();
       void cleanup(void);
       long read(lStdHep &ls);
@@ -325,6 +329,10 @@ private:
    class Event {
    public:
       Event();
+      /// no copy constructor
+      Event(const Event&) = delete ;
+      /// no assignment operator
+      Event& operator=(const Event&) = delete ;
       ~Event();
       void cleanup(void);
       long read(lStdHep &ls);

--- a/src/cpp/include/UTIL/lXDR.hh
+++ b/src/cpp/include/UTIL/lXDR.hh
@@ -116,10 +116,10 @@ public:
 private:
    char      *_fileName;
    FILE      *_fp;
-   long       _error;
-   bool       _openForWrite;
+   long       _error{0};
+   bool       _openForWrite{false};
 
-   bool       _hasNetworkOrder;
+  bool       _hasNetworkOrder{false};
    double     ntohd(double d) const;
    double     htond(double d) const { return(ntohd(d)); };
 

--- a/src/cpp/include/pre-generated/EVENT/LCFloatVec.h
+++ b/src/cpp/include/pre-generated/EVENT/LCFloatVec.h
@@ -32,9 +32,9 @@ public:
     typedef LCFloatVec lcobject_type ;
 
     public:
-    int id() const { return _acc.simpleUID() ; } 
+      int id() const { return _acc.simpleUID() ; } 
     protected:
-      IMPL::AccessChecked _acc ;
+      IMPL::AccessChecked _acc{} ;
 }; // class
 } // namespace EVENT
 #endif /* ifndef EVENT_LCFLOATVEC_H */

--- a/src/cpp/include/pre-generated/EVENT/LCIntVec.h
+++ b/src/cpp/include/pre-generated/EVENT/LCIntVec.h
@@ -31,9 +31,9 @@ public:
     typedef LCIntVec lcobject_type ;
 
     public:
-    int id() const { return _acc.simpleUID() ; } 
+      int id() const { return _acc.simpleUID() ; } 
     protected:
-      IMPL::AccessChecked _acc ;
+      IMPL::AccessChecked _acc{} ;
 }; // class
 } // namespace EVENT
 #endif /* ifndef EVENT_LCINTVEC_H */

--- a/src/cpp/include/pre-generated/EVENT/LCStrVec.h
+++ b/src/cpp/include/pre-generated/EVENT/LCStrVec.h
@@ -31,9 +31,9 @@ public:
     typedef LCStrVec lcobject_type ;
 
     public:
-    int id() const { return _acc.simpleUID() ; } 
+      int id() const { return _acc.simpleUID() ; } 
     protected:
-      IMPL::AccessChecked _acc ;
+      IMPL::AccessChecked _acc{} ;
 }; // class
 } // namespace EVENT
 #endif /* ifndef EVENT_LCSTRVEC_H */

--- a/src/cpp/src/CPPFORT/lciof77apiext.cc
+++ b/src/cpp/src/CPPFORT/lciof77apiext.cc
@@ -188,14 +188,14 @@ int lcgetmcparticledata( PTRTYPE mcparticle, int* pdg, int* genstatus, int* sims
 }
 
 
-int lcaddsimtrackerhit( PTRTYPE collectionvec, int cellID, double* pos, float dEdx, 
+int lcaddsimtrackerhit( PTRTYPE collectionvec, int cellID0, double* pos, float dEdx, 
 			    float time, PTRTYPE mcp ){
 
   LCCollectionVec* lcCollectionVec = reinterpret_cast<LCCollectionVec*>( (collectionvec) ) ;
   SimTrackerHitImpl* hit = new SimTrackerHitImpl ;
   MCParticle* mmcp = f2c_pointer<MCParticle,LCObject>( mcp ) ;
 
-  hit->setCellID( cellID ) ;
+  hit->setCellID0( cellID0 ) ;
   hit->setPosition( pos ) ;
   hit->setdEdx( dEdx ) ;
   hit->setTime( time ) ;

--- a/src/cpp/src/CPPFORT/lcsth.cc
+++ b/src/cpp/src/CPPFORT/lcsth.cc
@@ -78,11 +78,6 @@ int lcsthgetquality( PTRTYPE hit ){
   return sth->getQuality() ;
 }
 
-int lcsthsetcellid( PTRTYPE hit, int id ){
-  SimTrackerHitImpl* sth = f2c_pointer<SimTrackerHitImpl,LCObject>( hit ) ;
-  sth->setCellID( id ) ;
-  return LCIO::SUCCESS ;
-}
 int lcsthsetcellid0( PTRTYPE hit, int id ){
   SimTrackerHitImpl* sth = f2c_pointer<SimTrackerHitImpl,LCObject>( hit ) ;
   sth->setCellID0( id ) ;

--- a/src/cpp/src/EXAMPLE/CalibrationConstant.h
+++ b/src/cpp/src/EXAMPLE/CalibrationConstant.h
@@ -34,7 +34,7 @@ public:
 
   /** 'Copy constructor' needed to interpret LCCollection read from file/database.
    */
-  CalibrationConstant(LCObject* obj) : LCFixedObject<NINT,NFLOAT,NDOUBLE>(obj) { } 
+  CalibrationConstant(LCObject* o) : LCFixedObject<NINT,NFLOAT,NDOUBLE>(o) { } 
 
   /** Important for memory handling*/
   virtual ~CalibrationConstant() { /* no op*/  }

--- a/src/cpp/src/EXAMPLE/addRandomAccess.cc
+++ b/src/cpp/src/EXAMPLE/addRandomAccess.cc
@@ -66,9 +66,7 @@ int main(int argc, char** argv ){
 	    
 	    int status = fread( &bla[0] , sizeof(char) , 16 , f ) ;
 	    
-	    //	    std::cout << "  ====== read : [" << bla << "]" << std::endl ; 
-	    
-	    if( !strcmp( bla.c_str() , "LCIORandomAccess")  ){ 
+	    if( !strcmp( bla.c_str() , "LCIORandomAccess") || status != 16 ){ 
 	      
 	      
 	      status = fseek( f ,  -(16) , SEEK_CUR ) ;
@@ -77,7 +75,6 @@ int main(int argc, char** argv ){
 	      
 	      status = fwrite( &bla[0] , 1 , 16 , f ) ;
 	      
-	      //	      std::cout << "  --------- wrote " << bla << " to file - bytes written " << status << std::endl; 
 	    } 
 	  }
 

--- a/src/cpp/src/EXAMPLE/copyfix.cc
+++ b/src/cpp/src/EXAMPLE/copyfix.cc
@@ -23,11 +23,13 @@ using namespace lcio ;
 class RunEventProcessor : public LCRunListener, public LCEventListener{
   
 protected:
-  LCWriter* lcWrt ;
-  int nEvent ;
+  LCWriter* lcWrt{NULL} ;
+  int nEvent{0} ;
   
 public:
-  
+  RunEventProcessor(const RunEventProcessor&) = delete ;
+  RunEventProcessor operator=(const RunEventProcessor&) = delete ;
+
   RunEventProcessor(const char* outFileName) : nEvent(0) {
     
     // open outputfile

--- a/src/cpp/src/EXAMPLE/lcio_merge_files.cc
+++ b/src/cpp/src/EXAMPLE/lcio_merge_files.cc
@@ -23,13 +23,16 @@ using namespace lcio ;
 class RunEventProcessor : public LCRunListener, public LCEventListener{
 
     protected:
-        LCWriter* lcWrt ;
-        int nEvent ;
-        unsigned int _nFiles ;
+        LCWriter* lcWrt{NULL} ;
+        int nEvent{0} ;
+        unsigned int _nFiles{0} ;
 
     public:
 
-        RunEventProcessor(const char* outFileName, unsigned int nFiles) : nEvent(0), _nFiles(nFiles) {
+       RunEventProcessor(const RunEventProcessor&) = delete ;
+       RunEventProcessor operator=(const RunEventProcessor&) = delete ;
+
+       RunEventProcessor(const char* outFileName, unsigned int nFiles) : nEvent(0), _nFiles(nFiles) {
 
             // open outputfile
             lcWrt = LCFactory::getInstance()->createLCWriter() ;

--- a/src/cpp/src/EXAMPLE/lcio_split_file.cc
+++ b/src/cpp/src/EXAMPLE/lcio_split_file.cc
@@ -23,11 +23,14 @@ using namespace lcio ;
 class RunEventProcessor : public LCRunListener, public LCEventListener{
   
 protected:
-  LCWriter* lcWrt ;
-  int nEvent ;
+  LCWriter* lcWrt{NULL} ;
+  int nEvent{0} ;
   
 public:
   
+  RunEventProcessor(const RunEventProcessor&) = delete ;
+  RunEventProcessor operator=(const RunEventProcessor&) = delete ;
+
   RunEventProcessor(const char* outFileName, int splitSize) : nEvent(0) {
     
     // open outputfile

--- a/src/cpp/src/EXAMPLE/recjob.cc
+++ b/src/cpp/src/EXAMPLE/recjob.cc
@@ -54,11 +54,14 @@ static const int nRecP = 10 ; // number of reconstructed particles
 class RunEventProcessor : public LCRunListener, public LCEventListener{
   
 protected:
-  LCWriter* lcWrt ;
-  int nEvent ;
+  LCWriter* lcWrt{} ;
+  int nEvent{0} ;
   
 public:
   
+  RunEventProcessor(const RunEventProcessor&) = delete ;
+  RunEventProcessor operator=(const RunEventProcessor&) = delete ;
+
   RunEventProcessor() : nEvent(0) {
     
     // open outputfile

--- a/src/cpp/src/EXAMPLE/recjob.cc
+++ b/src/cpp/src/EXAMPLE/recjob.cc
@@ -18,11 +18,8 @@
 #include "IMPL/ClusterImpl.h" 
 #include "IMPL/ReconstructedParticleImpl.h" 
 #include "IMPL/VertexImpl.h" 
-//#include "IMPL/ParticleIDImpl.h" 
-//#include "IMPL/LCFlagImpl.h" 
 #include "UTIL/LCTOOLS.h"
 #include "UTIL/PIDHandler.h"
-//#include "UTIL/IndexMap.h"
 #include "IMPL/LCRelationImpl.h"
 
 #include "UTIL/LCRelationNavigator.h"

--- a/src/cpp/src/EXAMPLE/stdhepjob.cc
+++ b/src/cpp/src/EXAMPLE/stdhepjob.cc
@@ -50,11 +50,11 @@ int main(int argc, char** argv ){
   rdr.printHeader() ;
 
   // create sio writer
-  std::auto_ptr<LCWriter> lcWrt( LCFactory::getInstance()->createLCWriter() ) ;
+  std::unique_ptr<LCWriter> lcWrt( LCFactory::getInstance()->createLCWriter() ) ;
   
   lcWrt->open( outFile )  ;
   
-  std::auto_ptr<LCRunHeaderImpl> runHdr(  new LCRunHeaderImpl ) ; 
+  std::unique_ptr<LCRunHeaderImpl> runHdr(  new LCRunHeaderImpl ) ; 
   
   runHdr->setRunNumber( 0 ) ;
   
@@ -75,7 +75,7 @@ int main(int argc, char** argv ){
 
     while( maxEvt < 0  || count < maxEvt ){
 	
-      std::auto_ptr<LCEventImpl> evt( new LCEventImpl() ) ;
+      std::unique_ptr<LCEventImpl> evt( new LCEventImpl() ) ;
 	
       evt->setRunNumber(  0   ) ;
       evt->setEventNumber( count ) ;

--- a/src/cpp/src/EXAMPLE/stdhepjob_new.cc
+++ b/src/cpp/src/EXAMPLE/stdhepjob_new.cc
@@ -50,11 +50,11 @@ int main(int argc, char** argv ){
   rdr.printHeader() ;
 
   // create sio writer
-  std::auto_ptr<LCWriter> lcWrt( LCFactory::getInstance()->createLCWriter() ) ;
+  std::unique_ptr<LCWriter> lcWrt( LCFactory::getInstance()->createLCWriter() ) ;
   
   lcWrt->open( outFile )  ;
   
-  std::auto_ptr<LCRunHeaderImpl> runHdr(  new LCRunHeaderImpl ) ; 
+  std::unique_ptr<LCRunHeaderImpl> runHdr(  new LCRunHeaderImpl ) ; 
   
   runHdr->setRunNumber( 0 ) ;
   
@@ -75,7 +75,7 @@ int main(int argc, char** argv ){
 
     while( maxEvt < 0  || count < maxEvt ){
 	
-      std::auto_ptr<LCEventImpl> evt( new LCEventImpl() ) ;
+      std::unique_ptr<LCEventImpl> evt( new LCEventImpl() ) ;
 	
       evt->setRunNumber(  0   ) ;
       evt->setEventNumber( count ) ;

--- a/src/cpp/src/IMPL/ClusterImpl.cc
+++ b/src/cpp/src/IMPL/ClusterImpl.cc
@@ -9,19 +9,8 @@ namespace IMPL{
 
 
   ClusterImpl::ClusterImpl() :
-    _type(0),
-    _energy(0),
-    _energyError(0),
-    _theta(0),
-    _phi(0) {
-
-    _errpos.resize( NERRPOS ) ;
-    _errdir.resize( NERRDIR ) ;
-//     for(int i=0 ; i < NERRPOS ; i++ ) { _errpos.push_back( 0.0 ) ;  }
-//     for(int i=0 ; i < NERRDIR ; i++ ) { _errdir.push_back( 0.0 ) ;  }
-    _position[0] = 0. ;
-    _position[1] = 0. ;
-    _position[2] = 0. ;
+    _errpos( NERRPOS ),
+    _errdir( NERRDIR ){
   }
 
   ClusterImpl::~ClusterImpl(){

--- a/src/cpp/src/IMPL/LCCollectionVec.cc
+++ b/src/cpp/src/IMPL/LCCollectionVec.cc
@@ -9,32 +9,11 @@ using namespace EVENT ;
 
 namespace IMPL {
 
-//     std::string _typeName ;
-//     int _flag ;
-
 
 LCCollectionVec::LCCollectionVec( const std::string& type ) :
   _typeName( type ),
-  _flag(0){ 
-  //,
-  // _access(LCIO::UPDATE ) {
-
-}
+  _flag(0) {}
   
-// LCCollectionVec::LCCollectionVec( const EVENT::LCCollection& col ) :
-//   _typeName( col.getTypeName() ),
-//   _flag( col.getFlag() ),
-//   _access( col._access ) {
-
-//   // deep copy of all elements  - requires clone of original elements
-//   //
-//   int nElements = col.getNumberOfElements() ;
-
-//   for(int i=0; i< nElements ; i++){
-//     push_back(  col.getElementAt( i )->clone() ) ;
-//   }
-
-// }
 
   // overwrite the default implementation
   // set flag in all elements

--- a/src/cpp/src/IMPL/LCEventImpl.cc
+++ b/src/cpp/src/IMPL/LCEventImpl.cc
@@ -21,24 +21,6 @@ LCEventImpl::LCEventImpl() :
   _detectorName("unknown") {
 }
   
-// LCEventImpl::LCEventImpl(const LCEvent& evt) : 
-//   _runNumber( evt.getRunNumber() ),
-//   _eventNumber( evt.getEventNumber() ),
-//   _timeStamp( evt.getTimeStamp() ),
-//   _detectorName( evt.getDetectorName().c_str() ),
-  
-//   std::vector<std::string>* strVec = evt.getCollectionNames() ;
-//   int nCol = strVec->size() ;
-  
-//   for( std::vector<std::string>::iterator name = strVec->begin() ; name != strVec->end() ; name++){
-    
-//     const LCCollection* col = evt.getCollection( *name ) ;
-//     col->getTypeName() ;
-    
-//     // to be done - need to create new LCCollectionVec and add to the event ...
-//   }
-
-// }
 
 LCEventImpl::~LCEventImpl() {
   //  std::cout << " ~LCEventImpl() : " << this << std::endl ;

--- a/src/cpp/src/IMPL/SimTrackerHitImpl.cc
+++ b/src/cpp/src/IMPL/SimTrackerHitImpl.cc
@@ -66,13 +66,6 @@ namespace IMPL {
 
   const float* SimTrackerHitImpl::getMomentum() const { return _p ; }
 
-  void SimTrackerHitImpl::setCellID( int id) {
-    UTIL::LCWarning::getInstance().printWarning( "SIMTRACKERHIT_DEPRECATED_SETCELLID" ) ;
-    //checkAccess("SimTrackerHitImpl::setCellID") ;
-    //_cellID = id ;
-    setCellID0( id );
-  }
-
   void SimTrackerHitImpl::setCellID0( int id0) {
     checkAccess("SimTrackerHitImpl::setCellID0") ;
     _cellID0 = id0 ; 

--- a/src/cpp/src/IMPL/TrackImpl.cc
+++ b/src/cpp/src/IMPL/TrackImpl.cc
@@ -10,15 +10,11 @@ namespace IMPL {
   
     TrackImpl::TrackImpl() :
         _type(0),
-        //_isReferencePointPCA(0),
         _chi2(0),
         _ndf(0),
         _dEdx(0),
         _dEdxError(0),
         _radiusOfInnermostHit(0) { 
-
-            //_type.set( BIT_ISREFERENCEPOINTDCA ) ;
-
         }
 
   // copy constructor
@@ -44,15 +40,12 @@ namespace IMPL {
 
     std::copy( o._tracks.begin() ,  o._tracks.end() , std::back_inserter( _tracks ) ) ;
 
+    _trackStates.reserve(  o._trackStates.size() ) ;
     for( unsigned int i=0; i< o._trackStates.size() ; i++ ){
-      //_trackStates.push_back( new TrackStateImpl(  *dynamic_cast<TrackStateImpl*>( o._trackStates[i] ) ) ) ; 
       _trackStates.push_back( new TrackStateImpl(  *o._trackStates[i] ) ) ;
     }
 
-    // return back the object
-    // needed when calling multiple assignments,
-    // e.g. a = b = c ;
-    return o ;
+    return *this ;
     }
 
 

--- a/src/cpp/src/IMPL/TrackStateImpl.cc
+++ b/src/cpp/src/IMPL/TrackStateImpl.cc
@@ -24,32 +24,28 @@ namespace IMPL {
         _phi(0),
         _omega(0),
         _z0(0),
-        _tanLambda(0)
+        _tanLambda(0),
+	_covMatrix(TRKSTATENCOVMATRIX)
     {
-
-        for(int i=0 ; i < TRKSTATENCOVMATRIX ; i++ ) {
-            _covMatrix.push_back( 0.0 ) ; 
-        }
-
-        for(int i=0 ; i < TRKSTATENREFSIZE ; i++ ) {
+        for(int i=0 ; i < TRKSTATENREFSIZE ; ++i ) {
             _reference[i] = 0.0 ;
         }
 
     }
 
     TrackStateImpl::TrackStateImpl(int location, float d0, float phi, float omega, float z0, float tanLambda, const float* covMatrix, const float* reference) :
-        //_location(location),
         _d0(d0),
         _phi(phi),
         _omega(omega),
         _z0(z0),
-        _tanLambda(tanLambda)
+        _tanLambda(tanLambda),
+	_covMatrix(TRKSTATENCOVMATRIX)
     {
 
         setLocation( location );
 
-        for(int i=0 ; i < TRKSTATENCOVMATRIX ; i++ ) {
-            _covMatrix.push_back( covMatrix[i] ) ; 
+        for(int i=0 ; i < TRKSTATENCOVMATRIX ; ++i ) {
+            _covMatrix[i] = covMatrix[i] ; 
         }
 
         setReferencePoint(reference);
@@ -57,7 +53,6 @@ namespace IMPL {
 
 
     TrackStateImpl::TrackStateImpl(int location, float d0, float phi, float omega, float z0, float tanLambda, const FloatVec& covMatrix, const float* reference) :
-        //_location(location),
         _d0(d0),
         _phi(phi),
         _omega(omega),

--- a/src/cpp/src/IMPL/TrackerHitPlaneImpl.cc
+++ b/src/cpp/src/IMPL/TrackerHitPlaneImpl.cc
@@ -16,19 +16,9 @@ namespace IMPL {
     _EDepError(0),
     _time(0),
     _quality(0),
+    _cov( TRKHITPLANENCOVMATRIX ),
     _rawHits(0)
-    {
-    
-    _pos[0] = 0. ;
-    _pos[1] = 0. ;
-    _pos[2] = 0. ;
-    _u[0] = 0. ;
-    _u[1] = 0. ;
-    _v[0] = 0. ;
-    _v[1] = 0. ;
-    
-    _cov.resize( TRKHITPLANENCOVMATRIX ) ;
-  }
+     {}
   
   TrackerHitPlaneImpl::~TrackerHitPlaneImpl(){  
   } 

--- a/src/cpp/src/IMPL/TrackerHitZCylinderImpl.cc
+++ b/src/cpp/src/IMPL/TrackerHitZCylinderImpl.cc
@@ -11,23 +11,14 @@ namespace IMPL {
     _cellID1(0),
 
     _type(0),
-    //_r(0),
     _drphi(0),
     _dz(0),
     _EDep(0),
     _EDepError(0),
     _time(0),
     _quality(0),
+    _cov(TRKHITZCYLNCOVMATRIX ), 
     _rawHits(0) {
-    
-    _pos[0] = 0. ;
-    _pos[1] = 0. ;
-    _pos[2] = 0. ;
-    _center[0] = 0. ;
-    _center[1] = 0. ;
-
-    _cov.resize( TRKHITZCYLNCOVMATRIX ) ;
-
   }
   
   TrackerHitZCylinderImpl::~TrackerHitZCylinderImpl(){  

--- a/src/cpp/src/IMPL/TrackerPulseImpl.cc
+++ b/src/cpp/src/IMPL/TrackerPulseImpl.cc
@@ -12,17 +12,10 @@ namespace IMPL{
     _cellID0(0) ,
     _cellID1(0) ,
     _time(0),
-    //_timeError(0),
     _charge(0),
-    //_chargeError(0),
     _quality(0),
-    _corrData(0) {
-
-    _cov.resize( TRKPULSENCOVMATRIX ) ;
-    //for(int i=0; i<TRKPULSENCOVMATRIX; i++){
-    //  _cov.push_back(0.0) ;
-    //}
-
+    _corrData(0),
+    _cov( TRKPULSENCOVMATRIX ){
   }    
   
   /// Destructor.

--- a/src/cpp/src/IMPL/TrackerPulseImpl.cc
+++ b/src/cpp/src/IMPL/TrackerPulseImpl.cc
@@ -14,8 +14,8 @@ namespace IMPL{
     _time(0),
     _charge(0),
     _quality(0),
-    _corrData(0),
-    _cov( TRKPULSENCOVMATRIX ){
+    _cov( TRKPULSENCOVMATRIX ), 
+    _corrData(0){
   }    
   
   /// Destructor.

--- a/src/cpp/src/IMPL/VertexImpl.cc
+++ b/src/cpp/src/IMPL/VertexImpl.cc
@@ -7,17 +7,13 @@ namespace IMPL{
 
   VertexImpl::VertexImpl() :
     _primary(0),
+    _type("Unknown"),
     _chi2(0),
     _probability(0),
+    _cov( VTXCOVMATRIX ),
     _par(0),
     _aParticle(0)
-  {
-    _type="Unknown";
-    _cov.resize( VTXCOVMATRIX ) ;
-    _vpos[0] = 0. ;
-    _vpos[1] = 0. ;
-    _vpos[2] = 0. ;
-  }
+  {}
 
   VertexImpl::~VertexImpl(){ }
  

--- a/src/cpp/src/SIO/LCSIO.cc
+++ b/src/cpp/src/SIO/LCSIO.cc
@@ -244,8 +244,6 @@ std::string LCSIO::getValidSIOName(const std::string& aName ) {
 
     else if( (*name>=0) && ( isalnum( (int)*name ) || *name == '_' ) )
       *newName++ = *name ;
-    else
-    ; // ignore
   } 
   
   *newName = '\0' ;

--- a/src/cpp/src/SIO/SIOCollectionHandler.cc
+++ b/src/cpp/src/SIO/SIOCollectionHandler.cc
@@ -20,11 +20,11 @@ using namespace IOIMPL ;
 namespace SIO {
 
 
-  SIOCollectionHandler::SIOCollectionHandler(const std::string& name, 
+  SIOCollectionHandler::SIOCollectionHandler(const std::string& bname, 
 					     const std::string& type,
 					     LCEventIOImpl**  anEvtP)
     throw (Exception) : 
-    SIO_block( name.c_str() ), 
+    SIO_block( bname.c_str() ), 
     _evtP( anEvtP ) , _col(0) , 
     _myType( type )   {
     
@@ -145,10 +145,8 @@ namespace SIO {
   }
   
   unsigned int   SIOCollectionHandler::version(){
-    
-    int version = SIO_VERSION_ENCODE( LCIO::MAJORVERSION, LCIO::MINORVERSION ) ;
-    
-    return version ;
+
+    return SIO_VERSION_ENCODE( LCIO::MAJORVERSION, LCIO::MINORVERSION ) ;
   }
   
 } // namespace

--- a/src/cpp/src/SIO/SIOEventHandler.cc
+++ b/src/cpp/src/SIO/SIOEventHandler.cc
@@ -21,14 +21,14 @@ using namespace IOIMPL ;
 namespace SIO  {
 
 
-  SIOEventHandler::SIOEventHandler(const std::string& name) : 
-    SIO_block( name.c_str() ),
+  SIOEventHandler::SIOEventHandler(const std::string& bname) : 
+    SIO_block( bname.c_str() ),
     _evtP(0), 
     _evt(0) {
   }
 
-  SIOEventHandler::SIOEventHandler(const std::string& name, LCEventIOImpl** anEvtP) : 
-    SIO_block( name.c_str() ),
+  SIOEventHandler::SIOEventHandler(const std::string& bname, LCEventIOImpl** anEvtP) : 
+    SIO_block( bname.c_str() ),
     _evtP( anEvtP ), 
     _evt(0) {
  
@@ -193,9 +193,7 @@ namespace SIO  {
 
   unsigned int   SIOEventHandler::version(){
 
-    int version = SIO_VERSION_ENCODE( LCIO::MAJORVERSION, LCIO::MINORVERSION ) ;
-    return version ;
-
+   return SIO_VERSION_ENCODE( LCIO::MAJORVERSION, LCIO::MINORVERSION ) ;
   }
 
   void SIOEventHandler::setReadCollectionNames(const std::vector<std::string>& colnames){

--- a/src/cpp/src/SIO/SIOIndexHandler.cc
+++ b/src/cpp/src/SIO/SIOIndexHandler.cc
@@ -12,8 +12,8 @@
 namespace SIO  {
 
 
-  SIOIndexHandler::SIOIndexHandler(const std::string& name, LCIORandomAccessMgr* raMgr) : 
-    SIO_block( name.c_str() ),
+  SIOIndexHandler::SIOIndexHandler(const std::string& bname, LCIORandomAccessMgr* raMgr) : 
+    SIO_block( bname.c_str() ),
     _raMgr( raMgr ) {
     
   }
@@ -193,9 +193,7 @@ namespace SIO  {
   
   unsigned int   SIOIndexHandler::version(){
     
-    int version = SIO_VERSION_ENCODE( EVENT::LCIO::MAJORVERSION, EVENT::LCIO::MINORVERSION ) ;
-    return version ;
-    
+    return SIO_VERSION_ENCODE( EVENT::LCIO::MAJORVERSION, EVENT::LCIO::MINORVERSION ) ;
   }
   
 }

--- a/src/cpp/src/SIO/SIORandomAccessHandler.cc
+++ b/src/cpp/src/SIO/SIORandomAccessHandler.cc
@@ -12,8 +12,8 @@
 namespace SIO  {
 
 
-  SIORandomAccessHandler::SIORandomAccessHandler(const std::string& name, LCIORandomAccessMgr* raMgr) : 
-    SIO_block( name.c_str() ),
+  SIORandomAccessHandler::SIORandomAccessHandler(const std::string& bname, LCIORandomAccessMgr* raMgr) : 
+    SIO_block( bname.c_str() ),
     _raMgr( raMgr ) {
     
   }
@@ -91,9 +91,7 @@ namespace SIO  {
   
   unsigned int   SIORandomAccessHandler::version(){
     
-    int version = SIO_VERSION_ENCODE( EVENT::LCIO::MAJORVERSION, EVENT::LCIO::MINORVERSION ) ;
-    return version ;
-    
+    return SIO_VERSION_ENCODE( EVENT::LCIO::MAJORVERSION, EVENT::LCIO::MINORVERSION ) ;
   }
   
 }

--- a/src/cpp/src/SIO/SIORunHeaderHandler.cc
+++ b/src/cpp/src/SIO/SIORunHeaderHandler.cc
@@ -16,14 +16,14 @@ using namespace IOIMPL ;
 namespace SIO  {
 
 
-  SIORunHeaderHandler::SIORunHeaderHandler(const std::string& name) : 
-    SIO_block( name.c_str() ),
+  SIORunHeaderHandler::SIORunHeaderHandler(const std::string& bname) : 
+    SIO_block( bname.c_str() ),
     _rhP(0), 
     _hdr(0) {
   }
 
-  SIORunHeaderHandler::SIORunHeaderHandler(const std::string& name, IOIMPL::LCRunHeaderIOImpl** aRhP) : 
-    SIO_block( name.c_str() ),
+  SIORunHeaderHandler::SIORunHeaderHandler(const std::string& bname, IOIMPL::LCRunHeaderIOImpl** aRhP) : 
+    SIO_block( bname.c_str() ),
     _rhP( aRhP ), 
     _hdr(0) {
     
@@ -103,8 +103,8 @@ namespace SIO  {
 	int nSDN = strVec->size() ;
 	SIO_DATA( stream, &nSDN, 1 ) ;
 	
-	for( std::vector<std::string>::const_iterator name = strVec->begin() ; name != strVec->end() ; name++){
-	  LCSIO_WRITE( stream, *name ) ;
+	for( std::vector<std::string>::const_iterator nameI = strVec->begin() ; nameI != strVec->end() ; ++nameI){
+	  LCSIO_WRITE( stream, *nameI ) ;
 	} 
 	
 	// write parameters
@@ -125,9 +125,7 @@ namespace SIO  {
   
   unsigned int   SIORunHeaderHandler::version(){
     
-    int version = SIO_VERSION_ENCODE( LCIO::MAJORVERSION, LCIO::MINORVERSION ) ;
-    return version ;
-    
+    return SIO_VERSION_ENCODE( LCIO::MAJORVERSION, LCIO::MINORVERSION ) ;
   }
   
 }

--- a/src/cpp/src/UTIL/BitField64.cc
+++ b/src/cpp/src/UTIL/BitField64.cc
@@ -8,28 +8,28 @@ using namespace EVENT ;
 namespace UTIL{
   
   
-    BitFieldValue::BitFieldValue( lcio::long64& bitfield, const std::string& name, 
-				  unsigned offset, int signedWidth ) :
+    BitFieldValue::BitFieldValue( lcio::long64& bitfield, const std::string& theName, 
+				  unsigned theOffset, int signedWidth ) :
     _b(bitfield),
     _mask(0), 
-    _name( name ), 
-    _offset( offset ),
+    _name( theName ), 
+    _offset( theOffset ),
     _width( abs( signedWidth ) ),
     _minVal(0),
     _maxVal(0),
     _isSigned( signedWidth < 0 ) {
     
     // sanity check
-    if( offset > 63 || offset+_width > 64 ) {
+    if( _offset > 63 || _offset+_width > 64 ) {
       
       std::stringstream s ;
       s << " BitFieldValue '" << _name << "': out of range -  offset : " 
-	<< offset  << " width " << _width  ; 
+	<< _offset  << " width " << _width  ; 
       
       throw( Exception( s.str() ) ) ;
     }
     
-    _mask = ( ( 0x0001LL << _width ) - 1 ) << offset ;
+    _mask = ( ( 0x0001LL << _width ) - 1 ) << _offset ;
     
     
     // compute extreme values for later checks

--- a/src/cpp/src/UTIL/LCTime.cc
+++ b/src/cpp/src/UTIL/LCTime.cc
@@ -61,21 +61,21 @@ namespace UTIL{
   }
 
 
-  LCTime::LCTime(int year, int month, int day, int hour, int min, int s ){
+  LCTime::LCTime(int y, int mon, int d, int h, int m, int s ){
     
 
-    _d.year = year  ;
-    _d.month = month  ;
-    _d.day = day  ;
-    _d.hour = hour  ;
-    _d.min = min  ;
+    _d.year = y  ;
+    _d.month = mon  ;
+    _d.day = d  ;
+    _d.hour = h  ;
+    _d.min = m  ;
     _d.sec = s  ;
     _d.ns = 0 ; 
     
     // do some sanity checks on date:
-    if(  year  < YEAR0               || 
-	 month < 0     || month > 12 ||
-	 day   < 0     || day   > daysInMonth( month , year ) ){
+    if(  y  < YEAR0               || 
+	 mon < 0  || mon  > 12 ||
+	 d < 0    || d   > daysInMonth( mon , y ) ){
 
       throw Exception( "LCTime::LCTime() invalid date:"+ getDateString() ) ;
     } 
@@ -84,9 +84,9 @@ namespace UTIL{
     convertFromCalTime() ;
   }
   
-  LCTime::LCTime( int unixTime ) {
+  LCTime::LCTime( int unix_time) {
 
-    _t = unixTime * NPS ;
+    _t = unix_time * NPS ;
 
     convertToCalTime() ;
   }
@@ -193,19 +193,19 @@ namespace UTIL{
   }
 
    
-  int LCTime::daysInYear( int year ) const {
+  int LCTime::daysInYear( int y ) const {
     int d = DPY ;
-    if( isLeapYear( year ) ) d++ ;
+    if( isLeapYear( y ) ) ++d ;
     return d ;
   }
   
-  int LCTime::daysInMonth( int month , int year ) const {
+  int LCTime::daysInMonth( int mon , int y ) const {
     
-    if( month < 1 || month > 12 ) 
+    if( mon < 1 || mon > 12 ) 
       return 0 ;
-    int d = dpm[ month ] ;
+    int d = dpm[ mon ] ;
     
-    if( month == 2 &&  isLeapYear( year ) ) d++ ;
+    if( mon == 2 &&  isLeapYear( y ) ) d++ ;
     return d ;
   }
   

--- a/src/cpp/src/UTIL/lStdHep.cc
+++ b/src/cpp/src/UTIL/lStdHep.cc
@@ -175,7 +175,7 @@ long lStdHep::readEvent(void)
 
 long lStdHep::getEvent(lStdEvent &lse) const
 {
-   if (long status = getError() != LSH_SUCCESS) return(status);
+   if (long stat = getError() != LSH_SUCCESS) return(stat);
 
    lse.evtNum  = event.nevhep;
 
@@ -204,8 +204,8 @@ long lStdHep::getEvent(lStdEvent &lse) const
 
 long lStdHep::readEvent(lStdEvent &lse)
 {
-   long status = readEvent();
-   if (status != LSH_SUCCESS) return(status);
+   long stat = readEvent();
+   if (stat != LSH_SUCCESS) return(stat);
    return(getEvent(lse));
 }
 
@@ -288,8 +288,8 @@ long lStdHep::setEvent(const lStdEvent &lse)
 
 long lStdHep::writeEvent(lStdEvent &lse)
 {
-   long status = writeEvent();
-   if (status != LSH_SUCCESS) return(status);
+   long stat = writeEvent();
+   if (stat != LSH_SUCCESS) return(stat);
    return(setEvent(lse));
 }
 

--- a/src/cpp/src/UTIL/lXDR.cc
+++ b/src/cpp/src/UTIL/lXDR.cc
@@ -250,7 +250,11 @@ double *lXDR::readFloatArray(long &length)
    if (_hasNetworkOrder == false) {
       for (long i = 0; i < length; i++) {
          long l = ntohl(st[i]);
-         s[i] = (double) (*((float *) &l));
+	 //         s[i] = (double) (*((float *) &l));
+	 //fg: the above causes a strict aliasing error, so we sue memcpy
+	 float f ;
+	 memcpy( &f, &l, sizeof(float) ) ;
+	 s[i] = f ;
       }
    }
    _error = LXDR_SUCCESS;


### PR DESCRIPTION
BEGINRELEASENOTES
- fix all remaining compiler warnings from -Weffc++
       - using -Wno-non-virtual-dtor ( requires gcc 6 ) on older compilers these warnings will appear but can be safely ignored
ENDRELEASENOTES