### PR TITLE
Add flag -Wheader-hygiene to warn about usage of namespace directive i…

### DIFF
--- a/cmake/ilcsoft_default_cxx_flags.cmake
+++ b/cmake/ilcsoft_default_cxx_flags.cmake
@@ -4,7 +4,7 @@
 
 INCLUDE(CheckCXXCompilerFlag)
 
-SET(COMPILER_FLAGS -Wall -Wextra -Wshadow -Weffc++ -pedantic -Wno-long-long -Wuninitialized -Wno-non-virtual-dtor)
+SET(COMPILER_FLAGS -Wall -Wextra -Wshadow -Weffc++ -pedantic -Wno-long-long -Wuninitialized -Wno-non-virtual-dtor -Wheader-hygiene)
 
 IF( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
  LIST( APPEND COMPILER_FLAGS -Wl,-no-undefined )


### PR DESCRIPTION
…n global context in header

Based on discussion from yesterday we should probably start introducing it here

BEGINRELEASENOTES
- Added flag -Wheader-hygiene to warn about usage of namespace directive in global context in header

ENDRELEASENOTES