### PR TITLE
CellIDDecoder: replace static pointer to string with static string

### DIFF
--- a/src/cpp/include/UTIL/CellIDDecoder.h
+++ b/src/cpp/include/UTIL/CellIDDecoder.h
@@ -58,7 +58,7 @@ namespace UTIL{
       
       if( initString.size() == 0 ) {
 	
-	initString = *_defaultEncoding ;
+	initString = _defaultEncoding ;
 
 	std::cout << "    ----------------------------------------- " << std::endl  
 		  << "       WARNING: CellIDDecoder - no CellIDEncoding parameter in collection ! " 
@@ -103,22 +103,20 @@ namespace UTIL{
      *  CellIDEncoding parameter is set in the collection, e.g. in older lcio files.
      */ 
     static void setDefaultEncoding(const std::string& defaultEncoding ) {
-      
-      delete _defaultEncoding ;
-      
-      _defaultEncoding = new std::string( defaultEncoding ) ;
+
+      _defaultEncoding = std::string( defaultEncoding ) ;
     }
     
   protected:
     BitField64* _b{} ;
     const T* _oldHit{NULL} ;
     
-    static std::string*  _defaultEncoding ;
+    static std::string _defaultEncoding;
   } ; 
   
   template <class T>
-  std::string* CellIDDecoder<T>::_defaultEncoding 
-  = new std::string("byte0:8,byte1:8,byte2:8,byte3:8,byte4:8,byte5:8,byte6:8,byte7:8") ;
+  std::string CellIDDecoder<T>::_defaultEncoding
+  = std::string("byte0:8,byte1:8,byte2:8,byte3:8,byte4:8,byte5:8,byte6:8,byte7:8") ;
 
   
 } // namespace


### PR DESCRIPTION
solves some static initialisation/cleanup warnings from valgrind

```
==9435==    at 0x4A08D73: operator new(unsigned long) (vg_replace_malloc.c:332)
==9435==    by 0x514AC96: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) [clone .isra.97] (basic_string.tcc:219)
==9435==    by 0x5155925: __static_initialization_and_destruction_0 (CellIDDecoder.h:121)
==9435==    by 0x5155925: _GLOBAL__sub_I_LCTOOLS.cc (LCTOOLS.cc:1472)
==9435==    by 0x5176295: ??? (in .../lib/liblcio.so.2.9.0)
...
```

BEGINRELEASENOTES
- CellIDDecoder: use static string instead of static pointer to string for defaultEncoding

ENDRELEASENOTES