### PR TITLE
add SimCalorimeterHit::getLengthCont() (step length)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ PROJECT( LCIO )
 
 # project version
 SET( LCIO_VERSION_MAJOR 2 )
-SET( LCIO_VERSION_MINOR 10 )
-SET( LCIO_VERSION_PATCH 1 )
+SET( LCIO_VERSION_MINOR 11 )
+SET( LCIO_VERSION_PATCH 0 )
 
 ### set correct LCIO version in relevant files  ############################
 

--- a/cmake/lcio.xml.in
+++ b/cmake/lcio.xml.in
@@ -178,7 +178,7 @@
             </if>
          </repeat>
       </block>
-      <block name="SimTrackerHit" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="SimTrackerHit" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bit 31 Barrel = 0, Endcap = 1, Bit 30 momentum (not) stored: 1(0), Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -216,7 +216,7 @@
            </if>
          </repeat>
       </block>
-      <block name="SimCalorimeterHit" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="SimCalorimeterHit" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bit 31 long = 1, short = 0; Bit 30 Barrel = 0, Endcap = 1; 
               Bit 29 cellid1 = 1, no cellid1 = 0; Bit 28 PDG = 1, no PDG =0, Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
@@ -236,10 +236,11 @@
 		<data type="float" name="energyContrib"></data>
 		<data type="float" name="time"></data>
 		<if condition="(flags&amp;(1&lt;&lt;28)) != 0">
-		   <data type="int" name="PDG"></data>
-           <if condition="1000*major+minor&gt;1051">
-		        <data type="float[3]" name="stepPosition"></data>
-		    </if>
+		  <data type="float" name="length"></data>
+		  <data type="int" name="PDG"></data>
+                  <if condition="1000*major+minor&gt;1051">
+		    <data type="float[3]" name="stepPosition"></data>
+		  </if>
 		</if>
 
             </repeat>
@@ -248,7 +249,7 @@
            </if>
          </repeat>
       </block>
-      <block name="LCFloatVec" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="LCFloatVec" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">not yet used, Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="nVectors"></data>
@@ -262,7 +263,7 @@
            </if>
          </repeat>
       </block>
-      <block name="LCIntVec" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="LCIntVec" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">not yet used, Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="nVectors"></data>
@@ -276,7 +277,7 @@
            </if>
          </repeat>
       </block>
-      <block name="LCStrVec" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="LCStrVec" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">not yet used, Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="nVectors"></data>
@@ -290,7 +291,7 @@
            </if>
          </repeat>
       </block>
-      <block name="RawCalorimeterHit" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="RawCalorimeterHit" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bit 31 long = 1, short = 0; Bit 30 Barrel = 0, Endcap = 1; 
               Bit 29 cellid1 = 1, no cellid1 = 0;Bit 28 = 1: don't store ptr tag;
 	      Bit 27 = 1: timeStamp stored; Bits 0-15 user/detector specific</data>
@@ -310,7 +311,7 @@
 	    </if>
          </repeat>
       </block>
-      <block name="CalorimeterHit" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="CalorimeterHit" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bit 31 long = 1, short = 0; Bit 30 Barrel = 0, Endcap = 1; 
               Bit 29 cellid1 = 1, no cellid1 = 0;
 	      Bit 27 = 1: timeStamp stored; Bit 26 = 1: energy error stored;
@@ -345,7 +346,7 @@
             </if>
          </repeat>
       </block>
-      <block name="TrackerHit" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="TrackerHit" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -383,7 +384,7 @@
             <data type="ptag" name="this"></data>
          </repeat>
       </block>
-      <block name="TrackerHitPlane" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="TrackerHitPlane" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -421,7 +422,7 @@
             <data type="ptag" name="this"></data>
          </repeat>
       </block>
-      <block name="TrackerHitZCylinder" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="TrackerHitZCylinder" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -458,7 +459,7 @@
             <data type="ptag" name="this"></data>
          </repeat>
       </block>
-      <block name="TPCHit" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="TPCHit" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bit 31 no raw data = 0, raw data = 1, Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -484,7 +485,7 @@
             </if>
          </repeat>
       </block>
-      <block name="TrackerRawData" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="TrackerRawData" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -502,7 +503,7 @@
             <data type="ptag" name="this"></data>
          </repeat>
       </block>
-      <block name="TrackerData" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="TrackerData" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -520,7 +521,7 @@
             <data type="ptag" name="this"></data>
          </repeat>
       </block>
-      <block name="TrackerPulse" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="TrackerPulse" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -545,7 +546,7 @@
             <data type="ptag" name="this"></data>
          </repeat>
       </block>
-      <block name="SiliconRawHit" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="SiliconRawHit" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags">Bits 0-15 user/detector specific</data>
          <include subroutine="namedParameters"/>
          <data type="int" name="n"></data>
@@ -557,7 +558,7 @@
             <data type="ptag" name="this"></data>
          </repeat>
       </block>
-    <block name="Track" major="@LCIO_VERSION_MAJOR@" minor="8">
+    <block name="Track" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
       <data type="int" name="flag">Bit 31 Hits are kept =1, Hits are not kept = 0</data>
       <include subroutine="namedParameters"/>
       <data type="int" name="nTrack"/>
@@ -611,7 +612,7 @@
       <data type="ptag" name="this"></data>
       </repeat>
     </block>
-    <block name="Cluster" major="@LCIO_VERSION_MAJOR@" minor="8">
+    <block name="Cluster" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
       <data type="int" name="flag">Bit 31 Hits are kept =0, Hits are not kept = 1</data>
       <include subroutine="namedParameters"/>
       <data type="int" name="nCluster"/>
@@ -668,7 +669,7 @@
         <data type="ptag" name="this"></data>
       </repeat>
     </block>
-    <block name="Vertex" major="@LCIO_VERSION_MAJOR@" minor="8">
+    <block name="Vertex" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
       <data type="int" name="flag"></data>
       <include subroutine="namedParameters"/>
       <data type="int" name="nVertex"></data>
@@ -687,7 +688,7 @@
         <data type="ptag" name="this"></data>
     </repeat>
     </block>
-    <block name="ReconstructedParticle" major="@LCIO_VERSION_MAJOR@" minor="8">
+    <block name="ReconstructedParticle" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
       <data type="int" name="flag"></data>
       <include subroutine="namedParameters"/>
       <data type="int" name="nObject"/>
@@ -763,7 +764,7 @@
         <data type="ptag" name="this"></data>
       </repeat>
     </block>
-    <block name="LCGenericObject" major="@LCIO_VERSION_MAJOR@" minor="8">
+    <block name="LCGenericObject" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
       <data type="int" name="flag"></data>
         <include subroutine="namedParameters"/>
         <if condition="(flag&amp;(1&lt;&lt;31)) !=0">
@@ -790,7 +791,7 @@
         <data type="ptag" name="this"></data>
       </repeat>
     </block>
-    <block name="LCRelation" major="@LCIO_VERSION_MAJOR@" minor="8">
+    <block name="LCRelation" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
        <data type="int" name="flag">Bit 31: 1[0] Weights are [not] stored</data>
        <include subroutine="namedParameters"/>
        <data type="int" name="nRelations"/>
@@ -803,7 +804,7 @@
        </repeat>
     </block>
       <!-- generic block description for subset collections that hold references to existing objects -->
-      <block name="References" major="@LCIO_VERSION_MAJOR@" minor="8">
+      <block name="References" major="@LCIO_VERSION_MAJOR@" minor="@LCIO_VERSION_MINOR@">
          <data type="int" name="flags"></data>
          <include subroutine="namedParameters"/>
          <data type="int" name="nReferences"></data>

--- a/src/aid/EVENT/SimCalorimeterHit.aid
+++ b/src/aid/EVENT/SimCalorimeterHit.aid
@@ -65,11 +65,16 @@ public interface SimCalorimeterHit extends LCObject {
      */ 
     public float getEnergyCont(int i) const ;
 
-    /** Returns the time of the i-th in [ns]  contribution to the hit.
+    /** Returns the time in [ns] of the i-th contribution to the hit.
      * @see getNMCContributions()
-     */ 
+     */
     public float getTimeCont(int i) const ;
     
+    /** Returns the step length of the i-th contribution to the hit.
+     * @see getNMCContributions()
+     */
+    public float getLengthCont(int i) const ;
+
     /** Returns the PDG code of the shower particle that caused this contribution.
      *  Check the flag word bit LCIO.CHBIT_STEP of the collection whether this information 
      *  is available. 

--- a/src/cpp/include/IMPL/SimCalorimeterHitImpl.h
+++ b/src/cpp/include/IMPL/SimCalorimeterHitImpl.h
@@ -16,16 +16,18 @@ namespace IMPL {
       Particle(0) ,
       Energy(0.) ,
       Time(0.) ,
+      Length(0.),
       PDG(0)  {   
       StepPosition[0] = 0. ;
       StepPosition[1] = 0. ;
       StepPosition[2] = 0. ;
     }
 
-    MCParticleCont( EVENT::MCParticle* part,  float e,float t,int pdg, const float* step ) :
+    MCParticleCont( EVENT::MCParticle* part,  float e,float t,float l,int pdg, const float* step ) :
       Particle( part ) ,
       Energy(e) ,
       Time(t) ,
+      Length(l),
       PDG(pdg)  {   
       StepPosition[0] = step[0] ;
       StepPosition[1] = step[1] ;
@@ -35,6 +37,7 @@ namespace IMPL {
     EVENT::MCParticle* Particle ;
     float Energy ;
     float Time ;
+    float Length ;
     int   PDG ;
     float StepPosition[3] ;
   } ;
@@ -127,6 +130,11 @@ namespace IMPL {
      */ 
     virtual float getTimeCont(int i) const ;
 
+    /** Returns the step length of the i-th contribution to the hit.
+     * @see getNMCContributions()
+     */
+    virtual float getLengthCont(int i) const ;
+
     /** Returns the PDG code of the shower particle that caused this contribution.
      *  Check the flag word bit LCIO.CHBIT_STEP of the collection whether this information 
      *  is available. 
@@ -176,14 +184,31 @@ namespace IMPL {
      *  If stepPos==0, (0,0,0) will be stored.
      *  NB: The flag word bit LCIO::CHBIT_STEP (or LCIO::CHBIT_PDG) has to be set, in order for the PDG and step 
      *  position to be stored. 
+     *  @deprecated use addMCParticleContribution() with step length
      */
     void addMCParticleContribution( EVENT::MCParticle *p,
 				    float en,
 				    float t,
 				    int pdg, 
 				    float* stepPos=0
-				    ) ; 
+      ) {
+
+      addMCParticleContribution( p, en, t, 0., pdg, stepPos ) ;
+    } 
     
+    /** Adds a detailed MCParticle contribution to the hit. This method should be used for the detailed mode, where 
+     *  one MCParticleContribution is stored for every simulator step.<br>
+     *  If stepPos==0, (0,0,0) will be stored.
+     *  NB: The flag word bit LCIO::CHBIT_STEP (or LCIO::CHBIT_PDG) has to be set, in order for the PDG and step 
+     *  position to be stored. 
+     */
+    void addMCParticleContribution( EVENT::MCParticle *p,
+				    float en,
+				    float t,
+				    float l,
+				    int pdg, 
+				    float* stepPos=0
+				    ) ; 
     
 
 

--- a/src/cpp/include/pre-generated/EVENT/SimCalorimeterHit.h
+++ b/src/cpp/include/pre-generated/EVENT/SimCalorimeterHit.h
@@ -75,10 +75,15 @@ public:
      */ 
     virtual float getEnergyCont(int i) const = 0;
 
-    /** Returns the time of the i-th in [ns]  contribution to the hit.
+    /** Returns the time in [ns] of the i-th contribution to the hit.
      * @see getNMCContributions()
-     */ 
+     */
     virtual float getTimeCont(int i) const = 0;
+
+    /** Returns the step length of the i-th contribution to the hit.
+     * @see getNMCContributions()
+     */
+    virtual float getLengthCont(int i) const = 0;
 
     /** Returns the PDG code of the shower particle that caused this contribution.
      *  Check the flag word bit LCIO.CHBIT_STEP of the collection whether this information 

--- a/src/cpp/src/EXAMPLE/simjob.cc
+++ b/src/cpp/src/EXAMPLE/simjob.cc
@@ -254,7 +254,7 @@ int main(int argc, char** argv ){
 	  // in order to access a MCParticle,  we need a dynamic cast as the 
 	  // LCCollection returns an LCIOObject - this is like vectors in Java 
 	  hit->addMCParticleContribution(  dynamic_cast<MCParticle*>(mcVec->getElementAt( mcIndx )) , 
-					   0.314159, 0.1155, 1, pos ) ;
+					   0.314159, 0.1155, 42.,  1, pos ) ;
 	  
 	}
 	
@@ -264,40 +264,11 @@ int main(int argc, char** argv ){
 	  SimCalorimeterHitImpl* existingHit 
 	    = dynamic_cast<SimCalorimeterHitImpl*>( calVec->getElementAt(j) ) ; // << Ok now
 
- 	  //	    = dynamic_cast<SimCalorimeterHitImpl*>( (*calVec)[j] ) ;  // << not needed 
-	  
 	  existingHit->addMCParticleContribution( dynamic_cast<MCParticle*>
 						  (mcVec->getElementAt(0)), 
-						  0.1, 0. ) ; // no pdg
+						  0.1, 0. ) ; 
 	}
 
-// 	// ----- find the MCParticle with the largest contribution to the SimCalorimeterHits:
-// 	for(int j=0;j<NHITS;j++){
-
-// 	  SimCalorimeterHit* sh =
-// 	    dynamic_cast<SimCalorimeterHit*>( calVec->getElementAt(j) ) ; 
-
-// 	  typedef std::map<MCParticle*,double>  MCPMap ; 
-	  
-// 	  MCPMap mcpMap ;
-	  
-// 	  for( int ii=0 ;ii< sh->getNMCContributions() ; ++ii){
-// 	    mcpMap[  sh->getParticleCont(ii) ] += sh->getEnergyCont(ii) ;   
-// 	  }
-	  
-// 	  double eMax(0.) ; 
-// 	  MCParticle* mcp ;
-	  
-// 	  for( MCPMap::iterator it = mcpMap.begin() ;  it != mcpMap.end() ; ++it ){
-	    
-// 	    if( it->second > eMax ) {
-// 	      mcp = it->first ;
-// 	      eMax = it->second ;
-// 	    }
-// 	  } 
-// // 	  std::cout << " largest contribution " << eMax << " GeV from particle " 
-// // 		    << mcp << std::endl ;
-// 	}
 
 	// and finally some tracker hits
 	// with some user extensions (4 floats and 2 ints) per track:

--- a/src/cpp/src/IMPL/SimCalorimeterHitImpl.cc
+++ b/src/cpp/src/IMPL/SimCalorimeterHitImpl.cc
@@ -30,6 +30,7 @@ namespace IMPL{
     _position[2] = p[2] ;
 
     int nMC = hit.getNMCContributions() ;
+    _vec.reserve( nMC ) ; 
 
     // now copy all the MCParticle contributions
     for(int i=0; i<nMC ;i++){
@@ -37,6 +38,7 @@ namespace IMPL{
       MCParticleCont* con = new  MCParticleCont( hit.getParticleCont(i),
 						 hit.getEnergyCont(i),
 						 hit.getTimeCont(i),
+						 hit.getLengthCont(i),
 						 hit.getPDGCont(i),
 						 hit.getStepPosition(i) ) ;
       _vec.push_back( con ) ;
@@ -112,6 +114,9 @@ namespace IMPL{
   float SimCalorimeterHitImpl::getTimeCont(int i) const {
     return _vec[i]->Time ;
   }
+  float SimCalorimeterHitImpl::getLengthCont(int i) const {
+    return _vec[i]->Length ;
+  }
 
   int SimCalorimeterHitImpl::getPDGCont(int i) const{
     return _vec[i]->PDG ;
@@ -143,17 +148,17 @@ namespace IMPL{
   void SimCalorimeterHitImpl::addMCParticleContribution( EVENT::MCParticle *p,
 							 float en,
 							 float t ) {
-    
+
     checkAccess("SimCalorimeterHitImpl::addMCParticleContribution") ;
 
-   _energy += en ;
+    _energy += en ;
 
     static const float nullStep[3] = { 0.,0.,0. } ;
 
     // if we already have the particle, just add the energy
     for( std::vector<MCParticleCont*>::iterator it=_vec.begin(), End = _vec.end() ; it != End ; ++it ) {
-      
- 
+
+
     if( (*it)->Particle == p ) { 
 	
     	(*it)->Energy += en ;
@@ -161,7 +166,7 @@ namespace IMPL{
       }
     }
     // else create a new contribution
-    _vec.push_back( new MCParticleCont( p , en , t , 0 , nullStep )  )  ;
+    _vec.push_back( new MCParticleCont( p , en , t , 0 , 0 , nullStep )  )  ;
 
   }
   
@@ -170,6 +175,7 @@ namespace IMPL{
   void SimCalorimeterHitImpl::addMCParticleContribution( EVENT::MCParticle *p,
 							 float en,
 							 float t,
+							 float l,
 							 int pdg, 
 							 float* stepPos
 							 )  {
@@ -182,7 +188,7 @@ namespace IMPL{
     
      // add a new contribution :
 
-    _vec.push_back( new MCParticleCont( p , en , t , pdg ,  ( stepPos ? stepPos : nullStep )  )  )  ;
+    _vec.push_back( new MCParticleCont( p , en , t , l , pdg ,  ( stepPos ? stepPos : nullStep )  )  )  ;
 
     }
 } // namespace IMPL

--- a/src/cpp/src/SIO/SIOSimCalHitHandler.cc
+++ b/src/cpp/src/SIO/SIOSimCalHitHandler.cc
@@ -22,7 +22,9 @@ namespace SIO{
   unsigned int SIOSimCalHitHandler::read(SIO_stream* stream, 
 				      LCObject** objP){
     unsigned int status ; 
-	
+
+    LCFlagImpl flag(_flag) ;
+
     // create a new object :
     SimCalorimeterHitIOImpl* hit  = new SimCalorimeterHitIOImpl ;
     *objP = hit ;
@@ -30,7 +32,7 @@ namespace SIO{
     SIO_DATA( stream ,  &(hit->_cellID0) , 1  ) ;
 
     // in v00-08 cellid1 has been stored by default
-    if( LCFlagImpl(_flag).bitSet( LCIO::CHBIT_ID1 ) || 
+    if( flag.bitSet( LCIO::CHBIT_ID1 ) || 
 
 	( SIO_VERSION_MAJOR(_vers)==0 && SIO_VERSION_MINOR(_vers)==8) ){
 
@@ -39,13 +41,15 @@ namespace SIO{
     }
     SIO_DATA( stream ,  &(hit->_energy) , 1  ) ;
 
-    if( LCFlagImpl(_flag).bitSet( LCIO::CHBIT_LONG ) ){
+    if( flag.bitSet( LCIO::CHBIT_LONG ) ){
       SIO_DATA( stream ,  hit->_position  , 3 ) ;
     }
 
     // read MCContributions
     int nCon ;
     SIO_DATA( stream ,  &nCon , 1  ) ;
+
+    hit->_vec.reserve(nCon) ;
 
     for(int i=0; i< nCon ; i++){
 
@@ -54,17 +58,20 @@ namespace SIO{
       SIO_DATA( stream , &(mcCon->Energy) , 1 ) ;
       SIO_DATA( stream , &(mcCon->Time)   , 1 ) ;
 
-      if( LCFlagImpl(_flag).bitSet( LCIO::CHBIT_PDG ) ){  // BIT_PDG == BIT_STEP 
-	SIO_DATA( stream , &(mcCon->PDG)    , 1 ) ;
-      }
+      if( flag.bitSet( LCIO::CHBIT_STEP )){ 
 
-      if( _vers > SIO_VERSION_ENCODE( 1, 51 ) ){
-	if( LCFlagImpl(_flag).bitSet( LCIO::CHBIT_STEP ) ){
+	if( _vers > SIO_VERSION_ENCODE( 2, 10 ) ){
+	  SIO_DATA( stream , &(mcCon->Length) , 1 ) ;
+	}
+	SIO_DATA( stream , &(mcCon->PDG)  , 1 ) ;
+
+	if( _vers > SIO_VERSION_ENCODE( 1, 51 ) ){
 	  SIO_DATA( stream , &(mcCon->StepPosition[0])    , 1 ) ;
 	  SIO_DATA( stream , &(mcCon->StepPosition[1])    , 1 ) ;
 	  SIO_DATA( stream , &(mcCon->StepPosition[2])    , 1 ) ;
-        }
+	}
       }
+
       
       hit->_vec.push_back(  mcCon  );
     }
@@ -88,14 +95,17 @@ namespace SIO{
     const SimCalorimeterHit* hit = dynamic_cast<const SimCalorimeterHit*>(obj)  ;
     
     LCSIO_WRITE( stream, hit->getCellID0()  ) ;
-    if( LCFlagImpl(_flag).bitSet( LCIO::CHBIT_ID1 ) ){
+
+    LCFlagImpl flag(_flag) ;
+
+    if( flag.bitSet( LCIO::CHBIT_ID1 ) ){
       LCSIO_WRITE( stream, hit->getCellID1()  ) ;
     }
     LCSIO_WRITE( stream, hit->getEnergy()  ) ;
     // as SIO doesn't provide a write function with const arguments
     // we have to cast away the constness 
 
-    if( LCFlagImpl(_flag).bitSet( LCIO::CHBIT_LONG ) ){
+    if( flag.bitSet( LCIO::CHBIT_LONG ) ){
       float* pos = const_cast<float*> ( hit->getPosition() ) ; 
       SIO_DATA( stream,  pos , 3 ) ;
     }
@@ -111,14 +121,12 @@ namespace SIO{
       LCSIO_WRITE( stream, hit->getEnergyCont(i)  ) ;
       LCSIO_WRITE( stream, hit->getTimeCont(i)  ) ;
 
-      if( LCFlagImpl(_flag).bitSet( LCIO::CHBIT_STEP ) ){
+      if( flag.bitSet( LCIO::CHBIT_STEP ) ){
+
+	LCSIO_WRITE( stream, hit->getLengthCont(i)  ) ;
 
 	LCSIO_WRITE( stream, hit->getPDGCont(i)  ) ;
 
-	// const float* sp = hit->getStepPosition(i) ; 
-	// LCSIO_WRITE( stream, sp[0] ) ;
-	// LCSIO_WRITE( stream, sp[1] ) ;
-	// LCSIO_WRITE( stream, sp[2] ) ;
 	float* sp = const_cast<float*> ( hit->getStepPosition(i) ) ; 
 	SIO_DATA( stream,  sp , 3 ) ;
       }

--- a/src/cpp/src/UTIL/Operators.cc
+++ b/src/cpp/src/UTIL/Operators.cc
@@ -1283,7 +1283,7 @@ namespace UTIL{
     //============================================================================
 
     const std::string& header(const EVENT::SimCalorimeterHit *){ //hauke
-        static std::string _h(" [   id   ] |cellId0 |cellId1 |  energy  |        position (x,y,z)          | nMCParticles \n           -> MC contribution: prim. PDG |  energy  |   time   | sec. PDG | stepPosition (x,y,z) \n");
+        static std::string _h(" [   id   ] |cellId0 |cellId1 |  energy  |        position (x,y,z)          | nMCParticles \n           -> MC contribution: prim. PDG |  energy  |   time   | length  | sec. PDG | stepPosition (x,y,z) \n");
         return _h;
     }
 
@@ -1327,7 +1327,8 @@ namespace UTIL{
                 out << setw(6) << hit->getTimeCont(k) << "|";
 
                 if(flag.test(LCIO::CHBIT_STEP)){
-                    out << hit->getPDGCont( k ) << "| (" ;
+                    out << hit->getLengthCont( k ) << "| (" ;
+                    out << hit->getPDGCont( k ) << ", " ;
                     out << hit->getStepPosition( k )[0] << ", " ;
                     out << hit->getStepPosition( k )[1] << ", " ;
                     out << hit->getStepPosition( k )[2] << ")" ;
@@ -1411,6 +1412,7 @@ namespace UTIL{
                 out << setw(30) << left << "                Prim. PDG" << right << setw(40) << ( hit->getParticleCont(k) ? hit->getParticleCont(k)->getPDG()  : 0 ) << endl;
                 out << setw(30) << left << "                Energy [GeV]" << right << setw(40) << hit->getEnergyCont(k) << endl;
                 out << setw(30) << left << "                Time" << right << setw(40) << hit->getTimeCont(k) << endl;
+                out << setw(30) << left << "                Length" << right << setw(40) << hit->getLengthCont(k) << endl;
                 out << setw(30) << left << "                Sec. PDG" << right << setw(40) << hit->getPDGCont(k) << endl;
             }catch(exception& e){
                 out << e.what() << endl ;

--- a/src/java/hep/lcio/example/RecJob.java
+++ b/src/java/hep/lcio/example/RecJob.java
@@ -100,6 +100,10 @@ public class RecJob implements LCRunListener, LCEventListener
       // create a new collection to be added to the event
       ILCCollection calVec = new ILCCollection(LCIO.SIMCALORIMETERHIT);
 
+      int flag = 1 << LCIO.CHBIT_LONG;
+      flag = flag | (1 << LCIO.CHBIT_PDG); // include pdg as well
+      calVec.setFlag(flag);
+
       for (int j = 0; j < NHITS; j++)
       {
          ISimCalorimeterHit hit = new ISimCalorimeterHit();

--- a/src/java/hep/lcio/example/SimJob.java
+++ b/src/java/hep/lcio/example/SimJob.java
@@ -126,7 +126,7 @@ public class SimJob
                stepPos[2] = (float) 3.3 ;
                
                
-               hit.addMCParticleContribution((MCParticle) mcVec.getElementAt(mcIndx), 0.314159f, 0.1155f, 121212, stepPos );
+               hit.addMCParticleContribution((MCParticle) mcVec.getElementAt(mcIndx), 0.314159f, 0.1155f, 42.f , 121212, stepPos );
             }
 
             // and finally some tracker hits

--- a/src/java/hep/lcio/implementation/event/ISimCalorimeterHit.java
+++ b/src/java/hep/lcio/implementation/event/ISimCalorimeterHit.java
@@ -19,6 +19,7 @@ public class ISimCalorimeterHit extends ILCObject implements SimCalorimeterHit
    protected int[] pdg;
    protected float[] position = new float[3];
    protected float[] time;
+   protected float[] length;
    protected float energy;
    protected int cellId0;
    protected int cellId1;
@@ -103,17 +104,28 @@ public class ISimCalorimeterHit extends ILCObject implements SimCalorimeterHit
       return time[i];
    }
    
-   public void addMCParticleContribution(MCParticle p, float energy, float time, int pdg){
-       addMCParticleContribution( p , energy, time , pdg,  null ) ;
-   }
-   public void addMCParticleContribution(MCParticle p, float energy, float time, int pdg, float stepPos[])
-   {
+
+  public float getLengthCont(int i){
+    return length[i];
+  }
+
+  public void addMCParticleContribution(MCParticle p, float energy, float time, int pdg){
+    addMCParticleContribution( p , energy, time , 0 , pdg,  null ) ;
+  }
+  
+  public void addMCParticleContribution(MCParticle p, float energy, float time, int pdg, float stepPos[]){
+    addMCParticleContribution( p , energy, time , 0 , pdg,  stepPos ) ;
+  }
+
+  public void addMCParticleContribution(MCParticle p, float energy, float time, float length, int pdg, float stepPos[])
+    {
       checkAccess();
       
       int i = getIndexForNextContrib();
       this.particle[i] = p;
       this.energyContrib[i] = energy;
       this.time[i] = time;
+      this.length[i] = length;
       this.pdg[i] = pdg;
       
       if( steps==null ) steps = new ArrayList() ;
@@ -137,6 +149,8 @@ public class ISimCalorimeterHit extends ILCObject implements SimCalorimeterHit
          old = time;
          time = new float[size];
          if (oldSize > 0) System.arraycopy(old, 0, time, 0, oldSize);
+         length = new float[size];
+         if (oldSize > 0) System.arraycopy(old, 0, length, 0, oldSize);
          old = pdg;
          pdg = new int[size];
          if (oldSize > 0) System.arraycopy(old, 0, pdg, 0, oldSize);

--- a/src/java/hep/lcio/implementation/sio/SIOSimCalorimeterHit.java
+++ b/src/java/hep/lcio/implementation/sio/SIOSimCalorimeterHit.java
@@ -43,29 +43,37 @@ class SIOSimCalorimeterHit extends ISimCalorimeterHit
       time = new float[nContributions];
 
       boolean hasPDG = (flags & (1 << LCIO.CHBIT_PDG)) != 0;
-      if (hasPDG)
+      if (hasPDG){
          pdg = new int[nContributions];
+	 length = new float[nContributions];
+	 if( steps == null ) steps = new ArrayList() ;
+      }
       for (int i = 0; i < nContributions; i++)
       {
          particle[i] = in.readPntr();
          energyContrib[i] = in.readFloat();
          time[i] = in.readFloat();
+
          if (hasPDG) {
-            if( steps == null ) steps = new ArrayList() ;
-        	pdg[i] = in.readInt();
-            if( SIOVersion.encode(major,minor) > SIOVersion.encode(1,51)){
-                float[] st = new float[3] ;
-                st[0] = in.readFloat();
-                st[1] = in.readFloat();
-                st[2] = in.readFloat();          
-                steps.add( st ) ;
-            }
+
+	   if( SIOVersion.encode(major,minor) > SIOVersion.encode(2,10)){
+	     length[i] = in.readFloat();
+	   }
+	   pdg[i] = in.readInt();
+
+	   if( SIOVersion.encode(major,minor) > SIOVersion.encode(1,51)){
+	     float[] st = new float[3] ;
+	     st[0] = in.readFloat();
+	     st[1] = in.readFloat();
+	     st[2] = in.readFloat();          
+	     steps.add( st ) ;
+	   }
          }
          
-         }
-	  double version  = (double) major + ( (double) minor ) /  10. ;
-	  if( version > 1.0 )
-	    in.readPTag(this);
+      }
+      double version  = (double) major + ( (double) minor ) /  10. ;
+      if( version > 1.0 )
+	in.readPTag(this);
    }
 
    public MCParticle getParticleCont(int i)
@@ -102,6 +110,7 @@ class SIOSimCalorimeterHit extends ISimCalorimeterHit
             out.writeFloat(hit.getEnergyCont(i));
             out.writeFloat(hit.getTimeCont(i));
             if (hasPDG){
+               out.writeFloat(hit.getLengthCont(i));
                out.writeInt(hit.getPDGCont(i));
                float[] st = hit.getStepPosition(i) ;
                out.writeFloat( st[0] ) ;
@@ -134,6 +143,7 @@ class SIOSimCalorimeterHit extends ISimCalorimeterHit
          out.writeFloat(energyContrib[i]);
          out.writeFloat(time[i]);
          if (hasPDG){
+	   out.writeFloat(length[i]);
             out.writeInt(pdg[i]);
             float[] st = (float[]) steps.toArray()[i] ;
             out.writeFloat( st[0]) ;


### PR DESCRIPTION
BEGINRELEASENOTES
- add the step length to the MC-Contributions of the `SimCalorimeterHit`
  - add method `SimCalorimeterHit::getLengthCont(int) ` to access it 
  - only stored if `LCIO.CHBIT_STEP` is set (detailed shower mode)
  - implemented in C++ and Java (!?)
  - updated version number to v02-11
  - fixed some versions in ./cmake/lcio.xml.in

ENDRELEASENOTES