### PR TITLE
Remove dynamic exception specification

### DIFF
--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -7,6 +7,6 @@ cd /Package
 mkdir build
 cd build
 cmake -GNinja -DUSE_CXX11=ON -DBUILD_ROOTDICT=ON -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
-ninja && \
+ninja  -k 0 && \
 ninja install && \
 ctest --output-on-failure

--- a/src/aid/EVENT/LCCollection.aid
+++ b/src/aid/EVENT/LCCollection.aid
@@ -83,15 +83,22 @@ public interface LCCollection
      *
      * @throws ReadOnlyException
      */
+@ifdef cpp
+    public void addElement(LCObject* obj) noexcept(false) ;
+@else
     public void addElement(LCObject* obj) throws ReadOnlyException ;
-    
+@endif
     
     /** Removes the i-th element from the collection. Throws an exception 
      * if the collection (event) is 'read only'.
      *
      * @throws ReadOnlyException
      */
+@ifdef cpp
+    public void removeElementAt(int i) noexcept(false) ;
+@else
     public void removeElementAt(int i) throws ReadOnlyException ;
+@endif
     
 
     /** Set the flag word. This is allowed in 'read only' mode.

--- a/src/aid/EVENT/LCEvent.aid
+++ b/src/aid/EVENT/LCEvent.aid
@@ -46,7 +46,11 @@ public interface LCEvent {
      *
      * @throws DataNotAvailableException
      */
-     public LCCollection* getCollection(const String& name) const throws DataNotAvailableException ;
+@ifdef cpp
+    public LCCollection* getCollection(const String& name) const noexcept(false) ;
+@else
+    public LCCollection* getCollection(const String& name) const throws DataNotAvailableException ;
+@endif
 
 @ifdef cpp
     /** Returns the collection for the given name and transfers the ownership of the collection
@@ -57,7 +61,7 @@ public interface LCEvent {
      *  Use with care!
      * @throws DataNotAvailableException
      */
-     public LCCollection* takeCollection(const String& name) const throws DataNotAvailableException ;
+     public LCCollection* takeCollection(const String& name) const noexcept(false) ;
 @endif
 
     /** Adds a collection with the given name (has to be a valid C/C++ variable name). 
@@ -66,15 +70,24 @@ public interface LCEvent {
      *
      *@see validateCollectionName
      *@throws EventException
-     */ 
+     */
+@ifdef cpp
+    public void addCollection(LCCollection* col ,const  String& name ) noexcept(false) ;
+@else
     public void addCollection(LCCollection* col ,const  String& name ) throws EventException ;
+@endif
+
     
     /** Removes (and deletes) the collection with name (if it exists in the event). 
      * Throws an exception if the event is 'read only' as defined by the read mode in LCReader.
      *
      *@throws ReadOnlyException
-     */ 
+     */
+@ifdef cpp
+    public void removeCollection(const  String& name ) noexcept(false) ;
+@else
     public void removeCollection(const  String& name ) throws ReadOnlyException ;
+@endif
     
     /** Parameters defined for this event.
      */

--- a/src/aid/IO/LCReader.aid
+++ b/src/aid/IO/LCReader.aid
@@ -24,7 +24,12 @@ public interface LCReader {
      *
      * @throws IOException
      */
+@ifdef cpp
+    public void removeCollection(const  String& name ) noexcept(false) ;
+@else
     public void open(const String& filename) throws IOException  ;
+@endif
+
 
 
     /** Opens a list of files for reading (read-only). All subsequent
@@ -34,7 +39,12 @@ public interface LCReader {
      *
      * @throws IOException
      */
+@ifdef cpp
+    public void open(const String[]& filenames) noexcept(false) ;
+@else
     public void open(const String[]& filenames) throws IOException  ;
+@endif
+
 
 
     /** Reads the next run header from the file. Returns NULL if
@@ -42,28 +52,45 @@ public interface LCReader {
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCRunHeader* readNextRunHeader() noexcept(false) ;
+@else
     public LCRunHeader* readNextRunHeader() throws IOException ;
+@endif
     
     /** Same as readNextRunHeader() but allows to set the access mode 
      *  LCIO::READ_ONLY (default) or LCIO::Update. 
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCRunHeader* readNextRunHeader(int accessMode) noexcept(false) ;
+@else
     public LCRunHeader* readNextRunHeader(int accessMode) throws IOException ;
+@endif
     
     /** Reads the next event from the file. Returns NULL if
      * 'EOF' read. 
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCEvent* readNextEvent() noexcept(false) ;
+@else
     public LCEvent* readNextEvent() throws IOException ;
+@endif
     
     /** Same as readNextEvent() but allows to set the access mode 
      *  LCIO::READ_ONLY (default) or LCIO::Update. 
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCEvent* readNextEvent(int accessMode) noexcept(false) ;
+@else
     public LCEvent* readNextEvent(int accessMode) throws IOException ;
+@endif
+
 
     @ifdef cpp
 	
@@ -71,13 +98,13 @@ public interface LCReader {
      *  case several input files are specified in the open() method - 
      *  the number of events in the file that is currently open is returned. 
      */
-     public int getNumberOfEvents() throws IOException;
+     public int getNumberOfEvents() noexcept(false) ;
     
     /** Return the number of runs (run headers) in the file - the file has to be open. In
      *  case several input files are specified in the open() method - 
      *  the number of runs (run headers) in the file that is currently open is returned. 
      */
-     public int getNumberOfRuns() throws IOException;
+     public int getNumberOfRuns() noexcept(false) ;
      
     /** Return the run numbers of the runs (run headers) in the file - the file has to be open. In
      *  case several input files are specified in the open() method - 
@@ -105,41 +132,65 @@ public interface LCReader {
   /** Skips the next n events from the current position.
      * @throws IOException
      */
+@ifdef cpp
+    public void skipNEvents(int n) noexcept(false) ;
+@else
     public void skipNEvents(int n) throws IOException;
+@endif
 
     /** Reads the specified runHeader from file. Returns NULL if
      *  the specified runHeader hasn't been found in the file.
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCRunHeader* readRunHeader(int runNumber ) noexcept(false) ;
+@else
     public LCRunHeader* readRunHeader(int runNumber ) throws IOException  ;
+@endif
     
     /** Same as LCEvent* readRunHeader(int runNumber) 
      *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCRunHeader* readRunHeader(int runNumber, int accessMode) noexcept(false) ;
+@else
     public LCRunHeader* readRunHeader(int runNumber, int accessMode) throws IOException  ;
+@endif
 
     /** Reads the specified event from file. Returns NULL if
      *  the specified event hasn't been found in the file.
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCEvent* readEvent(int runNumber, int evtNumber) noexcept(false) ;
+@else
     public LCEvent* readEvent(int runNumber, int evtNumber) throws IOException  ;
+@endif
 
     /** Same as LCEvent* readEvent(int runNumber, int evtNumber) 
      *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
      *
      * @throws IOException
      */
+@ifdef cpp
+    public LCEvent* readEvent(int runNumber, int evtNumber, int accessMode) noexcept(false) ;
+@else
     public LCEvent* readEvent(int runNumber, int evtNumber, int accessMode) throws IOException  ;
+@endif
 
     /** Closes the output file/stream etc.
      *
      * @throws IOException
      */
+@ifdef cpp
+    public void close() noexcept(false) ;
+@else
     public void close() throws IOException ;
+@endif
 
     
     /** Registers a listener for reading LCEvents from a stream.
@@ -164,7 +215,11 @@ public interface LCReader {
      *
      * @throws IOException
      */
+@ifdef cpp
+    public void readStream() noexcept(false) ;
+@else
     public void readStream() throws IOException ;
+@endif
 
     /** Reads maxRecord from the input stream and notifies registered 
      * listeners according to the object type found in the stream.
@@ -172,5 +227,9 @@ public interface LCReader {
      *
      * @throws IOException
      */
+@ifdef cpp
+    public void readStream(int maxRecord) noexcept(false) ;
+@else
     public void readStream(int maxRecord) throws IOException ;
+@endif
 }

--- a/src/aid/IO/LCWriter.aid
+++ b/src/aid/IO/LCWriter.aid
@@ -19,7 +19,11 @@ public interface LCWriter {
      *
      *@throws IOException
      */
+@ifdef cpp
+    public void open(const String& filename ) noexcept(false) ;
+@else
     public void open(const String& filename ) throws IOException ;
+@endif
 
     /** Opens a file for writing.
      * Possible write modes are: LCIO::WRITE_NEW
@@ -27,7 +31,11 @@ public interface LCWriter {
      *
      *@throws IOException
      */
+@ifdef cpp
+    public void open(const String& filename , int writeMode ) noexcept(false) ;
+@else
     public void open(const String& filename , int writeMode ) throws IOException ;
+@endif
 
     
     /** Set the compression level - needs to be called before open() otherwise
@@ -53,23 +61,39 @@ public interface LCWriter {
      *
      *@throws IOException
      */
+@ifdef cpp
+    public void writeRunHeader(const LCRunHeader*  hdr) noexcept(false) ;
+@else
     public void writeRunHeader(const LCRunHeader*  hdr) throws IOException ;
+@endif
 
     /** Writes the given event to file.
      *
      *@throws IOException
      */
+@ifdef cpp
+    public void writeEvent(const LCEvent*  evt) noexcept(false) ;
+@else
     public void writeEvent(const LCEvent*  evt) throws IOException ;
+@endif
     
     /** Closes the output file/stream.
      *
      *@throws IOException
      */
+@ifdef cpp
+    public void close() noexcept(false) ;
+@else
     public void close() throws IOException ;
+@endif
 
     /** Flushes the output file/stream.
      *
      *@throws IOException
      */
-    public void flush() throws IOException ;    
+@ifdef cpp
+    public void flush() noexcept(false) ;
+@else
+    public void flush() throws IOException ;
+@endif
 }

--- a/src/cpp/include/IMPL/AccessChecked.h
+++ b/src/cpp/include/IMPL/AccessChecked.h
@@ -27,8 +27,8 @@ namespace IMPL {
   protected:
     virtual void setReadOnly( bool readOnly ) ;
     
-    void checkAccess() throw ( EVENT::ReadOnlyException ) ;
-    void checkAccess(const char* what) throw ( EVENT::ReadOnlyException ) ;
+    void checkAccess() noexcept(false) ;
+    void checkAccess(const char* what) noexcept(false) ;
 
   protected: 
     bool _readOnly{false} ;

--- a/src/cpp/include/IMPL/LCCollectionVec.h
+++ b/src/cpp/include/IMPL/LCCollectionVec.h
@@ -125,14 +125,14 @@ namespace IMPL {
      *
      * @throws ReadOnlyException
      */
-    virtual void addElement(EVENT::LCObject * obj) throw (EVENT::ReadOnlyException) ;
+    virtual void addElement(EVENT::LCObject * obj) noexcept(false) ;
 
     /** Removes the i-th element from the collection. Throws an exception 
      * if the collection (event) is 'read only'.
      *
      * @throws ReadOnlyException
      */
-    virtual void removeElementAt(int i) throw (EVENT::ReadOnlyException) ;
+    virtual void removeElementAt(int i) noexcept(false) ;
     
     /** Parameters defined for this run.
      */

--- a/src/cpp/include/IMPL/LCEventImpl.h
+++ b/src/cpp/include/IMPL/LCEventImpl.h
@@ -70,7 +70,7 @@ namespace IMPL{
      * @throws DataNotAvailableException
      */
     virtual EVENT::LCCollection * getCollection(const std::string & name) const 
-     throw (EVENT::DataNotAvailableException, std::exception) ;
+     noexcept(false) ;
 
     /** Returns the collection for the given name and transfers the ownership of the collection
      *  to the caller. The caller is responsible for deleting the collection _after_ the Event is 
@@ -81,7 +81,7 @@ namespace IMPL{
      * @throws DataNotAvailableException
      */
     virtual EVENT::LCCollection * takeCollection(const std::string & name) const 
-      throw (EVENT::DataNotAvailableException, std::exception ) ;
+      noexcept(false) ;
 
     /** Adds a collection with the given name (has to be a valid C/C++ variable name). 
      *	Throws an exception if the name already
@@ -91,14 +91,14 @@ namespace IMPL{
      *@throws EventException
      */ 
     virtual void addCollection(EVENT::LCCollection * col, const std::string & name)  
-      throw (EVENT::EventException, std::exception) ;
+      noexcept(false) ;
     
     /** Removes (and deletes) the collection with name (if it exists in the event). 
      * Throws an exception if the event is 'read only' as defined by the read mode in LCReader.
      *
      *@throws ReadOnlyException
      */ 
-    virtual void removeCollection(const std::string & name) throw (EVENT::ReadOnlyException, std::exception)  ;
+    virtual void removeCollection(const std::string & name) noexcept(false)  ;
     
 
 //     //fg20040528:   added relations to the event

--- a/src/cpp/include/SIO/SIOCollectionHandler.h
+++ b/src/cpp/include/SIO/SIOCollectionHandler.h
@@ -37,7 +37,7 @@ namespace SIO {
     SIOCollectionHandler(const std::string& name, 
 			 const std::string& type, 
 			 IOIMPL::LCEventIOImpl**  anEvtP=0 ) 
-      throw (EVENT::Exception) ;
+      noexcept(false) ;
 
     virtual ~SIOCollectionHandler() ;
 

--- a/src/cpp/include/SIO/SIOReader.h
+++ b/src/cpp/include/SIO/SIOReader.h
@@ -56,33 +56,33 @@ class SIOEventHandler ;
      * @throws IOException
      */
     virtual void open(const std::vector<std::string>& filenames) 
-      throw (IO::IOException, std::exception) ;
+      noexcept(false) ;
 
 
     /** Opens a file for reading (read-only).
      * @throws IOException
      */
-    virtual void open(const std::string & filename) throw (IO::IOException, std::exception) ;
+    virtual void open(const std::string & filename) noexcept(false) ;
     
     /** Reads the next run header from the file. 
      *
      * @throws IOException
      */
-    virtual EVENT::LCRunHeader * readNextRunHeader() throw (IO::IOException, std::exception) ;
+    virtual EVENT::LCRunHeader * readNextRunHeader() noexcept(false) ;
 
     /** Same as readNextRunHeader() but allows to set the access mode 
      *  LCIO::READ_ONLY (default) or LCIO::Update. 
      *
      * @throws IOException
      */
-    virtual EVENT::LCRunHeader * readNextRunHeader(int accessMode) throw (IO::IOException, std::exception) ;
+    virtual EVENT::LCRunHeader * readNextRunHeader(int accessMode) noexcept(false) ;
 
 
     /** Reads the next event from the file. 
      *
      * @throws IOException
      */
-    virtual EVENT::LCEvent* readNextEvent() throw (IO::IOException, std::exception) ;
+    virtual EVENT::LCEvent* readNextEvent() noexcept(false) ;
     
 
     /** Same as readNextRunHeader() but allows to set the access mode 
@@ -90,21 +90,21 @@ class SIOEventHandler ;
      *
      * @throws IOException
      */
-    virtual EVENT::LCEvent* readNextEvent( int accessMode) throw (IO::IOException, std::exception) ;
+    virtual EVENT::LCEvent* readNextEvent( int accessMode) noexcept(false) ;
     
 
     /** Return the number of events in the file - the file has to be open. In
      *  case several input files are specified in the open() method - 
      *  the number of events in the file that is currently open is returned. 
      */
-   virtual int getNumberOfEvents() throw (IO::IOException, std::exception ) ;
+   virtual int getNumberOfEvents() noexcept(false) ;
 
 
     /** Return the number of runs (run headers) in the file - the file has to be open. In
      *  case several input files are specified in the open() method - 
      *  the number of runs (run headers) in the file that is currently open is returned. 
      */
-    virtual int getNumberOfRuns() throw (IO::IOException, std::exception ) ;
+    virtual int getNumberOfRuns() noexcept(false) ;
 
 
     /** Return the run numbers of the runs (run headers) in the file - the file has to be open. In
@@ -125,7 +125,7 @@ class SIOEventHandler ;
     /** Skips the next n events from the current position. In fact simply reads the next n
       *  event headers so that the next event read is the (n+1)-th event.
       */
-    virtual void skipNEvents(int n)   throw (IO::IOException, std::exception )  ;
+    virtual void skipNEvents(int n)   noexcept(false)  ;
 
 
 
@@ -142,7 +142,7 @@ class SIOEventHandler ;
      * @throws IOException
      */
     virtual EVENT::LCRunHeader * readRunHeader(int runNumber ) 
-      throw (IO::IOException , std::exception) ;
+      noexcept(false) ;
 
     /** Same as LCEvent* readRunHeader(int runNumber) 
      *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
@@ -150,7 +150,7 @@ class SIOEventHandler ;
      * @throws IOException
      */
     virtual EVENT::LCRunHeader * readRunHeader(int runNumber, int accessMode ) 
-      throw (IO::IOException , std::exception) ;
+      noexcept(false) ;
 
     /** Reads the specified event from file. Returns NULL if
      *  the specified event hasn't been found in the file.
@@ -158,7 +158,7 @@ class SIOEventHandler ;
      * @throws IOException
      */
     virtual EVENT::LCEvent * readEvent(int runNumber, int evtNumber) 
-      throw (IO::IOException, std::exception ) ;
+      noexcept(false) ;
 
 
     /** Same as LCEvent* readEvent(int runNumber, int evtNumber 
@@ -167,13 +167,13 @@ class SIOEventHandler ;
      * @throws IOException
      */
     virtual EVENT::LCEvent * readEvent(int runNumber, int evtNumber, int accessMode) 
-      throw (IO::IOException, std::exception ) ;
+      noexcept(false) ;
     
     /** Closes the output file/stream etc.
      *
      * @throws IOException
      */
-    virtual void close() throw (IO::IOException, std::exception) ;
+    virtual void close() noexcept(false) ;
     
     // interface for listeners
  
@@ -200,7 +200,7 @@ class SIOEventHandler ;
      * @throws IOException
      * @throws EndOfException
      */
-    virtual void readStream() throw (IO::IOException, std::exception) ;
+    virtual void readStream() noexcept(false) ;
 
     /** Reads maxRecord from the input stream and notifies registered 
      * listeners according to the object type found in the stream. 
@@ -209,7 +209,7 @@ class SIOEventHandler ;
      * @throws IOException
      * @throws EndOfException
      */
-    virtual void readStream(int maxRecord) throw (IO::IOException, std::exception) ;
+    virtual void readStream(int maxRecord) noexcept(false) ;
 
 
 
@@ -217,7 +217,7 @@ class SIOEventHandler ;
   protected:
 
     void setUpHandlers() ;
-    void readRecord() throw (IO::IOException , IO::EndOfDataException , std::exception) ;
+    void readRecord() noexcept(false) ;
 
 
     void postProcessEvent() ;

--- a/src/cpp/include/SIO/SIOWriter.h
+++ b/src/cpp/include/SIO/SIOWriter.h
@@ -58,7 +58,7 @@ namespace SIO {
      *
      *@throws IOException
      */
-    virtual void open(const std::string & filename) throw (IO::IOException, std::exception) ;
+    virtual void open(const std::string & filename) noexcept(false) ;
 
     /** Opens a file for writing.
      * Possible write modes are: LCIO::WRITE_NEW
@@ -66,7 +66,7 @@ namespace SIO {
      *
      *@throws IOException
      */
-    virtual void open(const std::string & filename, int writeMode)throw (IO::IOException, std::exception) ;
+    virtual void open(const std::string & filename, int writeMode) noexcept(false) ;
     
     /** Set the compression level - needs to be called before open() otherwise
      *  call will have no effect. If not called the Writer will use default compression.<br>
@@ -88,25 +88,25 @@ namespace SIO {
      *
      *@throws IOException
      */
-    virtual void writeRunHeader(const EVENT::LCRunHeader * hdr)throw (IO::IOException, std::exception) ;
+    virtual void writeRunHeader(const EVENT::LCRunHeader * hdr) noexcept(false) ;
 
     /** Writes the given event to file.
      *
      *@throws IOException
      */
-    virtual void writeEvent(const EVENT::LCEvent * evt) throw (IO::IOException, std::exception) ;
+    virtual void writeEvent(const EVENT::LCEvent * evt) noexcept(false) ;
 
     /** Closes the output file/stream etc.
      *
      *@throws IOException
      */
-    virtual void close() throw (IO::IOException, std::exception) ;
+    virtual void close() noexcept(false) ;
     
     /** Flushes the output file/stream etc.
      *
      *@throws IOException
      */
-    virtual void flush() throw (IO::IOException, std::exception) ;
+    virtual void flush() noexcept(false) ;
 
 
   protected:

--- a/src/cpp/include/UTIL/LCSplitWriter.h
+++ b/src/cpp/include/UTIL/LCSplitWriter.h
@@ -53,7 +53,7 @@ namespace UTIL{
      *
      *@throws IO::IOException
      */
-    virtual void open(const std::string & filename) throw (IO::IOException, std::exception ) ;
+    virtual void open(const std::string & filename) noexcept(false) ;
 
     /** Not implemented - will throw an Exception if called.
      * Overwriting of or appending to split files is not straight forward. Pleas use the default write mode 
@@ -61,14 +61,14 @@ namespace UTIL{
      * 
      * @throws IO::IOException
      */
-    virtual void open(const std::string & filename, int writeMode) throw (IO::IOException, std::exception ) ;
+    virtual void open(const std::string & filename, int writeMode) noexcept(false) ;
 
     /** Writes the given run header to file. Opens a new file if the given file size is already exceeded
      *  before the execution of the write access.
      *
      * @throws IO::IOException
      */
-    virtual void writeRunHeader(const EVENT::LCRunHeader * hdr) throw (IO::IOException, std::exception ) ;
+    virtual void writeRunHeader(const EVENT::LCRunHeader * hdr) noexcept(false) ;
 
     /** Set CompressionLevel.
      * @see LCWriter::setCompressionLevel()
@@ -83,20 +83,20 @@ namespace UTIL{
      *
      *@throws IO::IOException
      */
-    virtual void writeEvent(const EVENT::LCEvent * evt) throw (IO::IOException, std::exception )  ;
+    virtual void writeEvent(const EVENT::LCEvent * evt) noexcept(false)  ;
 
     /** Closes the output file/stream.
      *
      *@throws IO::IOException
      */
-    virtual void close() throw (IO::IOException, std::exception )  ;
+    virtual void close() noexcept(false)  ;
 
 
     /** Flushes the output file/stream.
      *
      *@throws IO::IOException
      */
-    virtual void flush() throw (IO::IOException, std::exception )  ;
+    virtual void flush() noexcept(false)  ;
 
     
     //---------------------------------------------------------------------------------------------

--- a/src/cpp/include/pre-generated/EVENT/LCCollection.h
+++ b/src/cpp/include/pre-generated/EVENT/LCCollection.h
@@ -91,14 +91,14 @@ public:
      *
      * @throws ReadOnlyException
      */
-    virtual void addElement(LCObject * obj) throw (ReadOnlyException, std::exception )  = 0;
+    virtual void addElement(LCObject * obj) noexcept(false)  = 0;
 
     /** Removes the i-th element from the collection. Throws an exception 
      * if the collection (event) is 'read only'.
      *
      * @throws ReadOnlyException
      */
-    virtual void removeElementAt(int i) throw (ReadOnlyException, std::exception )  = 0;
+    virtual void removeElementAt(int i) noexcept(false)  = 0;
 
     /** Set the flag word. This is allowed in 'read only' mode.
      */

--- a/src/cpp/include/pre-generated/EVENT/LCEvent.h
+++ b/src/cpp/include/pre-generated/EVENT/LCEvent.h
@@ -63,7 +63,7 @@ public:
      *
      * @throws DataNotAvailableException
      */
-    virtual LCCollection * getCollection(const std::string & name) const throw (DataNotAvailableException, std::exception )  = 0;
+    virtual LCCollection * getCollection(const std::string & name) const noexcept(false) = 0;
 
     /** Returns the collection for the given name and transfers the ownership of the collection
      *  to the caller. The caller is responsible for deleting the collection _after_ the Event is 
@@ -73,7 +73,7 @@ public:
      *  Use with care!
      * @throws DataNotAvailableException
      */
-    virtual LCCollection * takeCollection(const std::string & name) const throw (DataNotAvailableException, std::exception )  = 0;
+    virtual LCCollection * takeCollection(const std::string & name) const noexcept(false) = 0;
 
     /** Adds a collection with the given name (has to be a valid C/C++ variable name). 
      *	Throws an exception if the name already
@@ -82,14 +82,14 @@ public:
      *@see validateCollectionName
      *@throws EventException
      */ 
-    virtual void addCollection(LCCollection * col, const std::string & name) throw (EventException, std::exception )  = 0;
+    virtual void addCollection(LCCollection * col, const std::string & name) noexcept(false) = 0;
 
     /** Removes (and deletes) the collection with name (if it exists in the event). 
      * Throws an exception if the event is 'read only' as defined by the read mode in LCReader.
      *
      *@throws ReadOnlyException
      */ 
-    virtual void removeCollection(const std::string & name) throw (ReadOnlyException, std::exception )  = 0;
+    virtual void removeCollection(const std::string & name) noexcept(false) = 0;
 
     /** Parameters defined for this event.
      */

--- a/src/cpp/include/pre-generated/IO/LCReader.h
+++ b/src/cpp/include/pre-generated/IO/LCReader.h
@@ -43,7 +43,7 @@ public:
      *
      * @throws IOException
      */
-    virtual void open(const std::string & filename) throw (IOException, std::exception )  = 0;
+    virtual void open(const std::string & filename) noexcept(false) = 0;
 
     /** Opens a list of files for reading (read-only). All subsequent
      * read operations will operate on the list, i.e. if an EOF is encountered
@@ -52,47 +52,47 @@ public:
      *
      * @throws IOException
      */
-    virtual void open(const std::vector<std::string>  & filenames) throw (IOException, std::exception )  = 0;
+    virtual void open(const std::vector<std::string>  & filenames) noexcept(false) = 0;
 
     /** Reads the next run header from the file. Returns NULL if
      * 'EOF' read. 
      *
      * @throws IOException
      */
-    virtual EVENT::LCRunHeader * readNextRunHeader() throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCRunHeader * readNextRunHeader() noexcept(false) = 0;
 
     /** Same as readNextRunHeader() but allows to set the access mode 
      *  LCIO::READ_ONLY (default) or LCIO::Update. 
      *
      * @throws IOException
      */
-    virtual EVENT::LCRunHeader * readNextRunHeader(int accessMode) throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCRunHeader * readNextRunHeader(int accessMode) noexcept(false) = 0;
 
     /** Reads the next event from the file. Returns NULL if
      * 'EOF' read. 
      *
      * @throws IOException
      */
-    virtual EVENT::LCEvent * readNextEvent() throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCEvent * readNextEvent() noexcept(false) = 0;
 
     /** Same as readNextEvent() but allows to set the access mode 
      *  LCIO::READ_ONLY (default) or LCIO::Update. 
      *
      * @throws IOException
      */
-    virtual EVENT::LCEvent * readNextEvent(int accessMode) throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCEvent * readNextEvent(int accessMode) noexcept(false) = 0;
 
     /** Return the number of events in the file - the file has to be open. In
      *  case several input files are specified in the open() method - 
      *  the number of events in the file that is currently open is returned. 
      */
-    virtual int getNumberOfEvents() throw (IOException, std::exception )  = 0;
+    virtual int getNumberOfEvents() noexcept(false) = 0;
 
     /** Return the number of runs (run headers) in the file - the file has to be open. In
      *  case several input files are specified in the open() method - 
      *  the number of runs (run headers) in the file that is currently open is returned. 
      */
-    virtual int getNumberOfRuns() throw (IOException, std::exception )  = 0;
+    virtual int getNumberOfRuns() noexcept(false) = 0;
 
     /** Return the run numbers of the runs (run headers) in the file - the file has to be open. In
      *  case several input files are specified in the open() method - 
@@ -117,41 +117,41 @@ public:
   /** Skips the next n events from the current position.
      * @throws IOException
      */
-    virtual void skipNEvents(int n) throw (IOException, std::exception )  = 0;
+    virtual void skipNEvents(int n) noexcept(false) = 0;
 
     /** Reads the specified runHeader from file. Returns NULL if
      *  the specified runHeader hasn't been found in the file.
      *
      * @throws IOException
      */
-    virtual EVENT::LCRunHeader * readRunHeader(int runNumber) throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCRunHeader * readRunHeader(int runNumber) noexcept(false) = 0;
 
     /** Same as LCEvent* readRunHeader(int runNumber) 
      *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
      *
      * @throws IOException
      */
-    virtual EVENT::LCRunHeader * readRunHeader(int runNumber, int accessMode) throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCRunHeader * readRunHeader(int runNumber, int accessMode) noexcept(false) = 0;
 
     /** Reads the specified event from file. Returns NULL if
      *  the specified event hasn't been found in the file.
      *
      * @throws IOException
      */
-    virtual EVENT::LCEvent * readEvent(int runNumber, int evtNumber) throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCEvent * readEvent(int runNumber, int evtNumber) noexcept(false) = 0;
 
     /** Same as LCEvent* readEvent(int runNumber, int evtNumber) 
      *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
      *
      * @throws IOException
      */
-    virtual EVENT::LCEvent * readEvent(int runNumber, int evtNumber, int accessMode) throw (IOException, std::exception )  = 0;
+    virtual EVENT::LCEvent * readEvent(int runNumber, int evtNumber, int accessMode) noexcept(false) = 0;
 
     /** Closes the output file/stream etc.
      *
      * @throws IOException
      */
-    virtual void close() throw (IOException, std::exception )  = 0;
+    virtual void close() noexcept(false) = 0;
 
     /** Registers a listener for reading LCEvents from a stream.
      */ 
@@ -175,7 +175,7 @@ public:
      *
      * @throws IOException
      */
-    virtual void readStream() throw (IOException, std::exception )  = 0;
+    virtual void readStream() noexcept(false) = 0;
 
     /** Reads maxRecord from the input stream and notifies registered 
      * listeners according to the object type found in the stream.
@@ -183,7 +183,7 @@ public:
      *
      * @throws IOException
      */
-    virtual void readStream(int maxRecord) throw (IOException, std::exception )  = 0;
+    virtual void readStream(int maxRecord) noexcept(false) = 0;
 }; // class
 } // namespace IO
 #endif /* ifndef IO_LCREADER_H */

--- a/src/cpp/include/pre-generated/IO/LCWriter.h
+++ b/src/cpp/include/pre-generated/IO/LCWriter.h
@@ -35,7 +35,7 @@ public:
      *
      *@throws IOException
      */
-    virtual void open(const std::string & filename) throw (IOException, std::exception )  = 0;
+    virtual void open(const std::string & filename) noexcept(false) = 0;
 
     /** Opens a file for writing.
      * Possible write modes are: LCIO::WRITE_NEW
@@ -43,7 +43,7 @@ public:
      *
      *@throws IOException
      */
-    virtual void open(const std::string & filename, int writeMode) throw (IOException, std::exception )  = 0;
+    virtual void open(const std::string & filename, int writeMode) noexcept(false) = 0;
 
     /** Set the compression level - needs to be called before open() otherwise
      *  call will have no effect. If not called the Writer will use default compression.<br>
@@ -67,25 +67,25 @@ public:
      *
      *@throws IOException
      */
-    virtual void writeRunHeader(const EVENT::LCRunHeader * hdr) throw (IOException, std::exception )  = 0;
+    virtual void writeRunHeader(const EVENT::LCRunHeader * hdr) noexcept(false) = 0;
 
     /** Writes the given event to file.
      *
      *@throws IOException
      */
-    virtual void writeEvent(const EVENT::LCEvent * evt) throw (IOException, std::exception )  = 0;
+    virtual void writeEvent(const EVENT::LCEvent * evt) noexcept(false) = 0;
 
     /** Closes the output file/stream.
      *
      *@throws IOException
      */
-    virtual void close() throw (IOException, std::exception )  = 0;
+    virtual void close() noexcept(false) = 0;
 
     /** Flushes the output file/stream.
      *
      *@throws IOException
      */
-    virtual void flush() throw (IOException, std::exception )  = 0;
+    virtual void flush() noexcept(false) = 0;
 }; // class
 } // namespace IO
 #endif /* ifndef IO_LCWRITER_H */

--- a/src/cpp/src/IMPL/AccessChecked.cc
+++ b/src/cpp/src/IMPL/AccessChecked.cc
@@ -13,11 +13,11 @@ namespace IMPL {
 
   void AccessChecked::setReadOnly( bool readOnly ) { _readOnly = readOnly ; }
   
-  void AccessChecked::checkAccess() throw ( EVENT::ReadOnlyException ){
+  void AccessChecked::checkAccess() noexcept(false){
 
     if( _readOnly ) throw EVENT::ReadOnlyException("") ;
   }
-  void AccessChecked::checkAccess(const char* what) throw ( EVENT::ReadOnlyException ){
+  void AccessChecked::checkAccess(const char* what) noexcept(false){
 
     if( _readOnly ){
       //      std::cout << " throwing ReadOnlyException " << what << std::endl ;

--- a/src/cpp/src/IMPL/LCCollectionVec.cc
+++ b/src/cpp/src/IMPL/LCCollectionVec.cc
@@ -100,7 +100,7 @@ void LCCollectionVec::setFlag(int flag){
 }
 
 
-  void LCCollectionVec::addElement(EVENT::LCObject * obj) throw (ReadOnlyException){
+  void LCCollectionVec::addElement(EVENT::LCObject * obj) noexcept(false){
     
     //    if(_access != LCIO::UPDATE )
     //  throw ReadOnlyException("LCCollectionVec::addElement:  event is read only") ;
@@ -108,7 +108,7 @@ void LCCollectionVec::setFlag(int flag){
     this->push_back( obj ) ; 
   }
 
-  void LCCollectionVec::removeElementAt(int i) throw (EVENT::ReadOnlyException){
+  void LCCollectionVec::removeElementAt(int i) noexcept(false){
     
     //    if(_access != LCIO::UPDATE )
     //  throw ReadOnlyException("LCCollectionVec::addElement:  event is read only") ;

--- a/src/cpp/src/IMPL/LCEventImpl.cc
+++ b/src/cpp/src/IMPL/LCEventImpl.cc
@@ -80,7 +80,7 @@ const std::vector<std::string>* LCEventImpl::getCollectionNames() const {
     
 
 LCCollection * LCEventImpl::getCollection(const std::string & name) const 
-  throw (DataNotAvailableException, std::exception) {
+  noexcept(false) {
 
   LCCollectionMap::iterator it = _colMap.find( name )  ;
 
@@ -101,7 +101,7 @@ LCCollection * LCEventImpl::getCollection(const std::string & name) const
 
 
 LCCollection * LCEventImpl::takeCollection(const std::string & name) const 
-  throw (DataNotAvailableException, std::exception) {
+  noexcept(false) {
 
   LCCollectionVec* col = dynamic_cast<LCCollectionVec*> ( getCollection( name ) ) ;
 
@@ -116,7 +116,7 @@ LCCollection * LCEventImpl::takeCollection(const std::string & name) const
     
 
 void  LCEventImpl::addCollection(LCCollection * col, const std::string & name) 
-  throw (EventException, std::exception)  {
+  noexcept(false) {
 
   
   if( ! validateCollectionName(name.c_str()) ){
@@ -142,7 +142,7 @@ void  LCEventImpl::addCollection(LCCollection * col, const std::string & name)
 
     
 
-void LCEventImpl::removeCollection(const std::string & name) throw (ReadOnlyException, std::exception) {
+void LCEventImpl::removeCollection(const std::string & name) noexcept(false) {
 
   // remove collection only, if access mode == update
   checkAccess("LCEventImpl::removeCollection") ;

--- a/src/cpp/src/SIO/SIOCollectionHandler.cc
+++ b/src/cpp/src/SIO/SIOCollectionHandler.cc
@@ -23,7 +23,7 @@ namespace SIO {
   SIOCollectionHandler::SIOCollectionHandler(const std::string& bname, 
 					     const std::string& type,
 					     LCEventIOImpl**  anEvtP)
-    throw (Exception) : 
+    noexcept(false) :
     SIO_block( bname.c_str() ), 
     _evtP( anEvtP ) , _col(0) , 
     _myType( type )   {

--- a/src/cpp/src/SIO/SIOReader.cc
+++ b/src/cpp/src/SIO/SIOReader.cc
@@ -102,7 +102,7 @@ namespace SIO {
 
 
   void SIOReader::open(const std::vector<std::string>& filenames) 
-    throw( IOException , std::exception){
+    noexcept(false) {
 
     unsigned int i;
     struct stat fileinfo ;
@@ -130,7 +130,7 @@ namespace SIO {
     open( _myFilenames[ ++_currentFileIndex ]  ) ;
   }
 
-  void SIOReader::open(const std::string& filename) throw( IOException , std::exception)  {
+  void SIOReader::open(const std::string& filename) noexcept(false) {
 
 
     std::string sioFilename ;  
@@ -172,7 +172,7 @@ namespace SIO {
 
 
 
-  int SIOReader::getNumberOfEvents() throw (IOException, std::exception ) {
+  int SIOReader::getNumberOfEvents() noexcept(false) {
 
     // create the event map if needed (i.e. not opened in direct access mode)
     if( ! _readEventMap ){  
@@ -186,7 +186,7 @@ namespace SIO {
     
   }
 
-  int SIOReader::getNumberOfRuns() throw (IOException, std::exception ) {
+  int SIOReader::getNumberOfRuns() noexcept(false) {
 
     // create the event map if needed (i.e. not opened in direct access mode)
     if( ! _readEventMap ){  
@@ -253,7 +253,7 @@ namespace SIO {
 
   //-------------------------------------------------------------------------------------------
 
-  void SIOReader::readRecord() throw (IOException , EndOfDataException , std::exception) {
+  void SIOReader::readRecord() noexcept(false) {
 
     SIO_blockManager::remove(  LCSIO_RUNBLOCKNAME ) ;
     SIO_blockManager::add( _runHandler ) ;
@@ -300,11 +300,11 @@ namespace SIO {
   }
   
 
-  LCRunHeader* SIOReader::readNextRunHeader() throw (IOException , std::exception ) {
+  LCRunHeader* SIOReader::readNextRunHeader() noexcept(false) {
     return readNextRunHeader( LCIO::READ_ONLY ) ;
   }
 
-  LCRunHeader* SIOReader::readNextRunHeader(int accessMode) throw (IOException , std::exception ) {
+  LCRunHeader* SIOReader::readNextRunHeader(int accessMode) noexcept(false) {
 
     // set the _runRecord to unpack for this scope
     //SIOUnpack runUnp( SIOUnpack::RUN ) ;
@@ -376,13 +376,13 @@ namespace SIO {
   }
   
 
-  LCEvent* SIOReader::readNextEvent() throw (IOException , std::exception ) {
+  LCEvent* SIOReader::readNextEvent() noexcept(false) {
 
     return readNextEvent( LCIO::READ_ONLY ) ;
 
   }
 
-  LCEvent* SIOReader::readNextEvent(int accessMode) throw (IOException, std::exception ) {
+  LCEvent* SIOReader::readNextEvent(int accessMode) noexcept(false) {
     
 
     // first, we need to read the event header 
@@ -437,7 +437,7 @@ namespace SIO {
     }
   }
   
-  void SIOReader::skipNEvents(int n) throw (IO::IOException, std::exception) {
+  void SIOReader::skipNEvents(int n) noexcept(false) {
      
     if( n < 1 )  // nothing to skip
       return ;  
@@ -475,13 +475,13 @@ namespace SIO {
   }
 
   EVENT::LCRunHeader * SIOReader::readRunHeader(int runNumber) 
-    throw (IOException , std::exception) {
+    noexcept(false) {
 
     return readRunHeader( runNumber, EVENT::LCIO::READ_ONLY ) ;
   }
 
   EVENT::LCRunHeader * SIOReader::readRunHeader(int runNumber, int accessMode) 
-    throw (IOException , std::exception) {
+    noexcept(false) {
     
     if( _readEventMap ) {
       
@@ -520,13 +520,13 @@ namespace SIO {
 
 
   EVENT::LCEvent * SIOReader::readEvent(int runNumber, int evtNumber) 
-    throw (IOException , std::exception) {
+    noexcept(false) {
 
     return readEvent( runNumber, evtNumber , EVENT::LCIO::READ_ONLY ) ;
   }
 
   EVENT::LCEvent * SIOReader::readEvent(int runNumber, int evtNumber, int accessMode) 
-    throw (IOException , std::exception) {
+    noexcept(false) {
     
     if( _readEventMap ) {
       
@@ -623,7 +623,7 @@ namespace SIO {
    
   }
   
-  void SIOReader::close() throw (IOException, std::exception ){
+  void SIOReader::close() noexcept(false) {
   
     _raMgr.clear() ;
 
@@ -654,12 +654,12 @@ namespace SIO {
     _runListeners.erase( _runListeners.find( ls ) );
  }
 
-  void SIOReader::readStream() throw ( IO::IOException, std::exception ){
+  void SIOReader::readStream() noexcept(false) {
 
     int maxInt = INT_MAX ; // numeric_limits<int>::max() ;
     readStream( maxInt ) ;
   }
-  void SIOReader::readStream(int maxRecord) throw (IOException, std::exception ){
+  void SIOReader::readStream(int maxRecord) noexcept(false) {
     
 
     bool readUntilEOF = false ;

--- a/src/cpp/src/SIO/SIOWriter.cc
+++ b/src/cpp/src/SIO/SIOWriter.cc
@@ -77,7 +77,7 @@ namespace SIO {
 
 
 
-  void SIOWriter::open(const std::string & filename) throw(IOException, std::exception){
+  void SIOWriter::open(const std::string & filename) noexcept(false) {
 
     std::string sioFilename ;  
     getSIOFileName( filename, sioFilename ) ;
@@ -113,7 +113,7 @@ namespace SIO {
       sioFilename = filename ;    
   } 
 
-  void SIOWriter::open(const std::string& filename, int writeMode) throw(IOException, std::exception) {
+  void SIOWriter::open(const std::string& filename, int writeMode) noexcept(false) {
 
     
     // make sure filename has the proper extension (.slcio) 
@@ -184,7 +184,7 @@ namespace SIO {
   }
 
 
-  void SIOWriter::writeRunHeader(const EVENT::LCRunHeader * hdr)  throw(IOException, std::exception) {
+  void SIOWriter::writeRunHeader(const EVENT::LCRunHeader * hdr)  noexcept(false) {
 
 
     SIO_record* runRecord = LCSIO::records()[ SIORecords::Run ] ;
@@ -266,7 +266,7 @@ namespace SIO {
     } 
   }
 
-  void SIOWriter::writeEvent(const LCEvent* evt)  throw(IOException, std::exception) {
+  void SIOWriter::writeEvent(const LCEvent* evt)  noexcept(false) {
 
     
     //here we set up the collection handlers 
@@ -316,7 +316,7 @@ namespace SIO {
   }
 
 
-  void SIOWriter::close() throw (IOException, std::exception) {
+  void SIOWriter::close() noexcept(false) {
   
     
     _raMgr.writeRandomAccessRecords( _stream ) ;
@@ -334,7 +334,7 @@ namespace SIO {
 
   }
 
-  void SIOWriter::flush() throw (IOException, std::exception) {
+  void SIOWriter::flush() noexcept(false) {
   
     const std::string* streamName  = _stream->getName() ;
 

--- a/src/cpp/src/UTIL/LCSplitWriter.cc
+++ b/src/cpp/src/UTIL/LCSplitWriter.cc
@@ -28,18 +28,18 @@ namespace UTIL{
 
 
 
-  void LCSplitWriter::open(const std::string & filename) throw (IO::IOException, std::exception ) {
+  void LCSplitWriter::open(const std::string & filename) noexcept(false) {
     _count = 0 ;
     setBaseFilename( filename ) ;
     _wrt->open( getFilename() ) ;
   }
   
-  void LCSplitWriter::open(const std::string & , int ) throw (IO::IOException, std::exception ) {
+  void LCSplitWriter::open(const std::string & , int ) noexcept(false) {
       throw Exception(" LCSplitWriter doesn't support  NEW and APPEND mode ! "
 		      " Please remove your old file(s) and use the default mode." ) ;
   }
   
-  void LCSplitWriter::writeRunHeader(const EVENT::LCRunHeader * hdr) throw (IO::IOException, std::exception ) {
+  void LCSplitWriter::writeRunHeader(const EVENT::LCRunHeader * hdr) noexcept(false) {
 
     _wrt->flush() ;
     if( fileSize() > _maxBytes ) {
@@ -51,7 +51,7 @@ namespace UTIL{
     _wrt->writeRunHeader( hdr ) ;
   }
 
-  void LCSplitWriter::writeEvent(const EVENT::LCEvent * evt) throw (IO::IOException, std::exception ) {
+  void LCSplitWriter::writeEvent(const EVENT::LCEvent * evt) noexcept(false) {
 
     _wrt->flush() ;
 
@@ -70,11 +70,11 @@ namespace UTIL{
     _wrt->writeEvent( evt ) ;
    }
   
-  void LCSplitWriter::close() throw (IO::IOException, std::exception ) {
+  void LCSplitWriter::close() noexcept(false) {
     _wrt->close() ;
    }
 
-  void LCSplitWriter::flush() throw (IO::IOException, std::exception ) {
+  void LCSplitWriter::flush() noexcept(false) {
     _wrt->flush() ;
    }
 


### PR DESCRIPTION
replaces #34 
BEGINRELEASENOTES

 -  Replace dynamic exception specification with `noexcept(false)`

ENDRELEASENOTES