### PR TITLE
Fixwarn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,6 @@ MESSAGE( STATUS "" )
 
 
 # generate and install following configuration files
-GENERATE_PACKAGE_CONFIGURATION_FILES( LCIOConfig.cmake LCIOConfigVersion.cmake LCIOLibDeps.cmake )
+GENERATE_PACKAGE_CONFIGURATION_FILES( LCIOConfig.cmake LCIOConfigVersion.cmake )
 
 INSTALL( FILES cmake/MacroCheckPackageLibs.cmake cmake/MacroCheckPackageVersion.cmake DESTINATION lib/cmake)

--- a/cmake/MacroGeneratePackageConfigFiles.cmake
+++ b/cmake/MacroGeneratePackageConfigFiles.cmake
@@ -33,11 +33,6 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
             ENDIF( EXISTS "${PROJECT_SOURCE_DIR}/cmake/${arg}.in" )
         ENDIF()
 
-        IF( ${arg} MATCHES "LibDeps.cmake" )
-            EXPORT_LIBRARY_DEPENDENCIES( "${arg}" )
-            INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
-        ENDIF()
-
     ENDFOREACH()
 
 ENDMACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )

--- a/src/cpp/include/UTIL/LCFourVector.h
+++ b/src/cpp/include/UTIL/LCFourVector.h
@@ -30,11 +30,14 @@ namespace UTIL {
   class LCFourVector :  public HepLorentzVector {
 
   protected: 
-    const TT* _lcObj ;
+    const TT* _lcObj = nullptr ;
     
   public: 
     virtual ~LCFourVector() { /*no_op*/; } 
     
+    LCFourVector(const LCFourVector& ) = default ;
+    LCFourVector& operator=(const LCFourVector& ) = default ;
+
     /** Constructor for templated type,e.g. LCFourVector<MCParticle>( myMCParticle ).
      */
     inline LCFourVector( const TT* lcObj) : _lcObj(lcObj) {


### PR DESCRIPTION

BEGINRELEASENOTES
- fix last warnings (gcc5.4)
     - dont create LCIOLibDeps.cmake (fix Policy CMP0033) 
     - fix warnings in UTIL::LCFourVector 

ENDRELEASENOTES