### PR TITLE
Fix01

### DIFF
--- a/cmake/LCIOConfig.cmake.in
+++ b/cmake/LCIOConfig.cmake.in
@@ -54,7 +54,7 @@ CHECK_PACKAGE_LIBS( LCIO lcio sio )
 
 # ---------- libraries dependencies -------------------------------------------
 # this sets LCIO_${COMPONENT}_LIB_DEPENDS variables
-INCLUDE( "${LCIO_ROOT}/lib/cmake/LCIOLibDeps.cmake" )
+#INCLUDE( "${LCIO_ROOT}/lib/cmake/LCIOLibDeps.cmake" )
  
 
 

--- a/src/cpp/src/TESTS/test_randomaccess.cc
+++ b/src/cpp/src/TESTS/test_randomaccess.cc
@@ -112,7 +112,8 @@ int main(int /*argc*/, char** /*argv*/ ){
 
 
     MYTEST.LOG( "  -------------------------------------    test random access in file c_sim.slcio - file must exist in : "  ) ;
-    std::system("pwd") ;
+    if( !std::system("pwd") )
+	std::cout << "?" << std::endl ;
 
     // simjob.slcio has written 100 events in 10 runs, closing and re-opening the file after every run 
     //  this tests writing the random access records in append mode ...


### PR DESCRIPTION

BEGINRELEASENOTES
- fix unused warning in test_randomaccess.cc 
- bug fix in cmake/LCIOConfig.cmake.in (fixes DD4hep part of #45)

ENDRELEASENOTES