### PR TITLE
Fix dumpevent

### DIFF
--- a/src/cpp/include/UTIL/PIDHandler.h
+++ b/src/cpp/include/UTIL/PIDHandler.h
@@ -77,6 +77,7 @@ namespace UTIL{
     int getParameterIndex( int algorithmID, const std::string& pName ) ;
       
     /** Return the (first) ParticleID object for the given algorithm and particle (or cluster) - throws UnknownAlgorithm.
+     *  If no object is found for the given algorithmID a default initialized dummy object is returned.
      *  Only use if you know there is only one PID object for the algorithms or if you simply want the most likely
      *  PID for this algorithm.
      */

--- a/src/cpp/src/UTIL/LCTOOLS.cc
+++ b/src/cpp/src/UTIL/LCTOOLS.cc
@@ -1033,7 +1033,7 @@ namespace UTIL {
             cout << endl ;
         }
         catch( UnknownAlgorithm &e ){
-            cout << "- NA - ";
+	  cout << "- NA - " << std::endl ;
         }
 
         std::cout << endl
@@ -1066,17 +1066,19 @@ namespace UTIL {
 
                     const StringVec& pNames = pidH.getParameterNames(  pid->getAlgorithmType() ) ;
 
-                    for(unsigned j=0;j< pNames.size() ;++j){
+		    if(  pNames.size() == pid->getParameters().size() ) {
+		      for(unsigned j=0;j< pNames.size() ;++j){
 
                         cout << " " <<  pNames[j]
-                            << " : " <<  pid->getParameters()[j] << "," ; 
+			     << " : " <<  pid->getParameters()[j] << "," ; 
+		      }
+		    }
 
-                    }
                     cout << "]"<< endl ;
 
                 }
                 catch( UnknownAlgorithm &e ){
-                    cout << "- NA - ";
+		  cout << "- NA - " << std::endl ;
                 }
 
             }

--- a/src/cpp/src/UTIL/PIDHandler.cc
+++ b/src/cpp/src/UTIL/PIDHandler.cc
@@ -358,22 +358,10 @@ namespace UTIL{
 
     }
 	
-    // not returned, i.e. we need to create a new pid objects
+    // nothing found - return a dummy ParticleID object
 
-    ParticleIDImpl* pid = new ParticleIDImpl ;
-
-
-    if( _type == ReconstructedParticle  ){
-      
-      static_cast< ReconstructedParticleImpl* >(p)->addParticleID( pid ) ; 
-    }
-    else if( _type == Cluster  ){
-      
-      static_cast< ClusterImpl* >(p)->addParticleID( pid )  ; 
-    }
-
-
-    return *pid ;
+    static const ParticleIDImpl dummyPID ;
+    return dummyPID ;
   }
   
   void PIDHandler::setParticleID( LCObject* p ,


### PR DESCRIPTION

BEGINRELEASENOTES
- protect against invalid ParticleID objects in `LCTOOLS::printReconstructedParticles()`
         - these where added as a nasty side effect in `PIDHandler::getParticleID()`
- fix `PIDHandler::getParticleID()` accordingly
- fixes #47 
ENDRELEASENOTES