### PR TITLE
[LCIO-MT] Library thread safety cleanup : LCRTRelations

### DIFF
--- a/src/cpp/include/LCRTRelations.h
+++ b/src/cpp/include/LCRTRelations.h
@@ -5,7 +5,9 @@
 #include <vector>
 #include <list>
 #include <map>
+#ifndef __CINT__
 #include <typeindex>
+#endif
 #include <memory>
 
 #include <Exceptions.h>
@@ -527,7 +529,7 @@ namespace lcrtrel{
     
   private:
     /// The user extension map
-    mutable ext_map          _extensionMap {};
+    mutable ext_map          _extensionMap {};  //! exclude map from ROOT dictionaries ...
   } ;
   
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -260,6 +260,7 @@ ADD_LCIO_TEST( test_trackerhitplane )
 ADD_LCIO_TEST( test_trackerhitzcylinder )
 ADD_LCIO_TEST( test_trackerpulse )
 ADD_LCIO_TEST( test_randomaccess )  # needs output from t_c_sim
+ADD_LCIO_TEST( test_RTextension )
 ADD_LCIO_TEST( test_splitting )
 ADD_LCIO_TEST( test_lctrackercellid )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Refactored `LCRTRelations` class and friends
   - Removed global map for extension deletion
   - Introduced mechanism to store extension as `shared_ptr<void>` in a map
   - Fixes thread safety issue at the cost of introducing a small memory overhead per added extension
   - Exclude extension map from ROOT dictionaries I/O
      - because `std::type_index` has no default constructor
- Activated compilation of runtime extensions unit test

ENDRELEASENOTES