### PR TITLE
[LCIO-MT] MT::LCReader and parallel processing example

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -123,6 +123,10 @@ SET( LCIO_UTIL_SRCS
   ./src/UTIL/ILDConf.cc
 )
 
+SET( LCIO_MT_SRCS
+  ./src/MT/LCReader.cc
+)
+
 
 ###### macro for generating lcio c++ header files from aid files #############
 #
@@ -290,6 +294,7 @@ ADD_SHARED_LIBRARY( lcio
   ${LCIO_IOIMPL_SRCS}
   ${LCIO_UTIL_SRCS}
   ${LCIO_SIO_SRCS}
+  ${LCIO_MT_SRCS}
 )
 INSTALL_SHARED_LIBRARY( lcio DESTINATION lib )
 
@@ -470,6 +475,7 @@ ADD_LCIO_EXAMPLE( lcio_split_file )
 ADD_LCIO_EXAMPLE( lcio_merge_files ) 
 ADD_LCIO_EXAMPLE( readmcparticles ) 
 ADD_LCIO_EXAMPLE( lcio_parallel_read ) 
+ADD_LCIO_EXAMPLE( lcio_parallel_processing ) 
 
 IF( BUILD_LCIO_EXAMPLES )
   ADD_LCIO_EXAMPLE( lcrtrelation )

--- a/src/cpp/include/IOIMPL/LCEventIOImpl.h
+++ b/src/cpp/include/IOIMPL/LCEventIOImpl.h
@@ -11,6 +11,10 @@ namespace SIO {
   class SIOReader ;
 }
 
+namespace MT {
+  class LCReader ;
+}
+
 
 namespace IOIMPL {
   
@@ -25,6 +29,7 @@ namespace IOIMPL {
     friend class SIO::SIOReader ;
     friend class SIO::SIOEventHeaderHandler ;
     friend class SIO::SIOEventHandler ;
+    friend class MT::LCReader ;
   
   }; // class
 

--- a/src/cpp/include/IOIMPL/LCRunHeaderIOImpl.h
+++ b/src/cpp/include/IOIMPL/LCRunHeaderIOImpl.h
@@ -11,6 +11,10 @@ namespace SIO {
   class SIOReader ;
 }
 
+namespace MT {
+  class LCReader ;
+}
+
 
 namespace IOIMPL {
   
@@ -23,6 +27,7 @@ namespace IOIMPL {
     
   // the reason for having this subclass
     friend class SIO::SIOReader ;
+    friend class MT::LCReader ;
   
   }; // class
 

--- a/src/cpp/include/MT/LCReader.h
+++ b/src/cpp/include/MT/LCReader.h
@@ -1,0 +1,166 @@
+#ifndef MT_LCREADER_H
+#define MT_LCREADER_H 1
+
+// -- std headers
+#include <string>
+#include <vector>
+
+// -- lcio headers
+#include "MT/Types.h"
+#include "MT/LCReaderListener.h"
+#include "LCIOSTLTypes.h"
+#include "LCIOTypes.h"
+#include "EVENT/LCIO.h"
+
+// -- sio headers
+#include "SIO_definitions.h"
+
+namespace SIO {
+  class LCIORecords ;
+  class LCIORandomAccessMgr ;
+}
+
+namespace MT {
+
+/** Implementation of a LCReader for parallel processing use
+ *
+ * @see EXAMPLE/lcio_parallel_processing.cc
+ * @author rete
+ * @version Feb 14, 2019
+ */
+class LCReader {
+private:
+  // No copy
+  LCReader(const LCReader&) = delete;
+  LCReader& operator=(const LCReader&) = delete;
+
+public:
+  /// Bit for direct access
+  static const int directAccess =  0x00000001 << 0  ;
+
+public:
+  ~LCReader() = default;
+  
+  /**
+   *  @brief  Constructor
+   *
+   *  @param  lcReaderFlag flag for reader options
+   */
+  LCReader( int lcReaderFlag ) ;
+
+  /** Opens a file for reading (read-only).
+   */
+  void open( const std::string & filename );
+
+  /** Opens a list of files for reading (read-only). All subsequent
+   * read operations will operate on the list, i.e. if an EOF is encountered
+   * the next file in the list will be opened and read transparently to the
+   * user.
+   */
+  void open( const std::vector<std::string> & filenames ) ;
+
+  /** Reads the next run header from the file. 
+   *  Returns NULL if 'EOF' read.
+   *  Note that this method is not thread safe !
+   */
+  LCRunHeaderPtr readNextRunHeader( int accessMode = EVENT::LCIO::READ_ONLY ) ;
+
+  /** Reads the next event from the file. 
+   *  Returns NULL if 'EOF' read. 
+   *  Note that this method is not thread safe !
+   */
+  LCEventPtr readNextEvent( int accessMode = EVENT::LCIO::READ_ONLY ) ;
+
+  /** Return the number of events in the file - the file has to be open. In
+   *  case several input files are specified in the open() method - 
+   *  the number of events in the file that is currently open is returned. 
+   */
+  int getNumberOfEvents() ;
+
+  /** Return the number of runs (run headers) in the file - the file has to be open. In
+   *  case several input files are specified in the open() method - 
+   *  the number of runs (run headers) in the file that is currently open is returned. 
+   */
+  int getNumberOfRuns() ;
+
+  /** Return the run numbers of the runs (run headers) in the file - the file has to be open. In
+   *  case several input files are specified in the open() method - 
+   *  the run numbers of the runs (run headers) in the file that is currently open is returned. 
+   */
+  void getRuns( EVENT::IntVec & runs ) ;
+
+  /** Return the run and event numbers of the events in the file - the file has to be open. In
+   *  case several input files are specified in the open() method - 
+   *  the  run and event numbers of the events in the file that is currently open are returned.
+   *  The size of the vector events will be twice the number of events, where i-th run number
+   *  will be in events[2*i] and the i-th event number in  events[2*i+].
+   */
+  void getEvents( EVENT::IntVec & events ) ;
+
+  /** Limit the collection names that are going to be read to the subset given in the vector -
+   *  all other collection will be ignored. This might improve the reading performance
+   *  considerably in cases where only a small subset of the collections in the event is needed. 
+   */
+  void setReadCollectionNames( const std::vector<std::string> & colnames ) ;
+
+  /** Skips the next n events from the current position.
+   */
+  void skipNEvents( int n ) ;
+
+  /** Reads the specified runHeader from file. Returns NULL if
+   *  the specified runHeader hasn't been found in the file.
+   */
+  LCRunHeaderPtr readRunHeader( int runNumber , int accessMode = EVENT::LCIO::READ_ONLY ) ;
+
+  /** Reads the specified event from file. Returns NULL if
+   *  the specified event hasn't been found in the file.
+   */
+  LCEventPtr readEvent( int runNumber, int evtNumber , int accessMode = EVENT::LCIO::READ_ONLY ) ;
+
+  /** Closes the output file/stream etc.
+   */
+  void close() ;
+
+  /** Reads the input stream and notifies registered 
+   * listeners according to the object type 
+   * found in the stream. 
+   */
+  void readStream( const LCReaderListenerList & listeners ) ;
+
+  /** Reads maxRecord from the input stream and notifies registered 
+   * listeners according to the object type found in the stream.
+   * An exception is thrown if less than maxRecord where read from the file.
+   */
+  void readStream( const LCReaderListenerList & listeners , int maxRecord ) ;
+  
+  /** Reads the input stream and notifies registered 
+   * listeners according to the object type 
+   * found in the stream. 
+   */
+  void readNextRecord( const LCReaderListenerList & listeners ) ;
+    
+private:
+  void readRecord( const sio::record_map &records , sio::record_read_result &readResult ) ;
+  void postProcessEvent( EVENT::LCEvent *evt ) ;
+  void getEventMap() ;
+    
+private:
+  /// The SIO stream for reading
+  sio::stream_ptr _stream{nullptr} ;
+  /// The LCIO records holder
+  std::shared_ptr<SIO::LCIORecords> _lcioRecords {nullptr} ;
+  /// The list of files to open and read
+  std::vector<std::string> _myFilenames{} ;
+  /// A restricted list of collections to read only 
+  std::vector<std::string> _readCollectionNames{} ;
+  /// The current file list index when opening multiple files
+  unsigned int _currentFileIndex{0} ;
+  /// Whether to read the event map using the random access manager
+  bool _readEventMap{false} ;
+  /// The random access manager for event/run random access in the file 
+  std::shared_ptr<SIO::LCIORandomAccessMgr> _raMgr {nullptr} ;
+}; // class
+
+} // namespace MT
+
+#endif /* ifndef MT_LCREADER_H */

--- a/src/cpp/include/MT/LCReaderListener.h
+++ b/src/cpp/include/MT/LCReaderListener.h
@@ -1,0 +1,51 @@
+#ifndef MT_LCREADERLISTENER_H
+#define MT_LCREADERLISTENER_H 1
+
+// -- lcio headers
+#include "MT/Types.h"
+
+namespace MT {
+
+/**
+ *  @brief  LCReaderListener class
+ *          Interface for MT::LCReader::readStream() callbacks
+ */
+class LCReaderListener {
+public:
+  /**
+   *  @brief  Destructor
+   */
+  virtual ~LCReaderListener() {}
+
+  /**
+   *  @brief  modify an event 
+   * 
+   *  @param  event the event to modify
+   */
+  virtual void modifyEvent( LCEventPtr event ) = 0 ;
+
+  /**
+   *  @brief  process an event 
+   * 
+   *  @param  event the event to process
+   */
+  virtual void processEvent( LCEventPtr event ) = 0 ;
+
+  /**
+   *  @brief  modify a run header
+   * 
+   *  @param  hdr the run header to modify
+   */
+  virtual void modifyRunHeader( LCRunHeaderPtr hdr ) = 0 ;
+  
+  /**
+   *  @brief  process a run header
+   * 
+   *  @param  hdr the run header to process
+   */
+  virtual void processRunHeader( LCRunHeaderPtr hdr ) = 0 ;
+};
+
+} // namespace MT
+
+#endif /* ifndef MT_LCREADERLISTENER_H */

--- a/src/cpp/include/MT/Types.h
+++ b/src/cpp/include/MT/Types.h
@@ -1,0 +1,25 @@
+#ifndef MT_TYPES_H
+#define MT_TYPES_H 1
+
+// -- std headers
+#include <memory>
+#include <unordered_set>
+
+namespace EVENT {
+  class LCEvent ;
+  class LCRunHeader ;
+}
+
+namespace MT {
+  // forward declarations
+  class LCReader;
+  class LCReaderListener;
+  
+  // MT types
+  typedef std::shared_ptr<EVENT::LCEvent>      LCEventPtr ;
+  typedef std::shared_ptr<EVENT::LCRunHeader>  LCRunHeaderPtr ;
+  typedef std::unordered_set<LCReaderListener*> LCReaderListenerList;
+    
+} // namespace MT
+
+#endif /* ifndef MT_TYPES_H */

--- a/src/cpp/src/EXAMPLE/lcio_parallel_processing.cc
+++ b/src/cpp/src/EXAMPLE/lcio_parallel_processing.cc
@@ -1,0 +1,159 @@
+#include "lcio.h"
+
+#include "MT/Types.h"
+#include "MT/LCReader.h"
+#include "MT/LCReaderListener.h"
+#include "UTIL/LCTOOLS.h"
+#include "IMPL/LCEventImpl.h"
+
+#include <cstdlib>
+#include <mutex>
+#include <future>
+#include <functional>
+#include <thread>
+#include <unistd.h>
+
+static std::vector<std::string> FILEN ; 
+
+using namespace std ;
+using namespace lcio ;
+using LCEventPtr = MT::LCEventPtr;
+using LCRunHeaderPtr = MT::LCRunHeaderPtr;
+
+std::mutex printMutex;
+#define SAFE_PRINT( message ) { std::lock_guard<std::mutex> lock(printMutex); std::cout << message << std::endl; }
+#define SAFE_CODE( code ) { std::lock_guard<std::mutex> lock(printMutex); code; }
+
+class Scheduler final : public MT::LCReaderListener {
+private:
+  typedef void                               task_return_type ;
+  typedef std::future<task_return_type>      future_type ;
+  typedef std::vector<future_type>           future_list ;
+  
+public:
+  Scheduler( unsigned int maxNTasks = std::thread::hardware_concurrency() ) :
+    _maxNTasks(maxNTasks) {
+    SAFE_PRINT( "Scheduler created with maxNTasks = " << _maxNTasks ) ;
+  }
+  
+  ~Scheduler() {
+    waitForAll();
+  }
+  
+  void startTask( LCEventPtr event ) {
+    while ( not canStartNewTask() ) {
+      processFinishedTasks() ;
+      usleep(1000) ;
+    }
+    SAFE_PRINT( "Starting new task ..." ) ;
+    _futures.push_back( std::async( std::launch::async, [](LCEventPtr evt) {
+      
+      SAFE_PRINT( "Task processing run no " 
+        << evt->getRunNumber() 
+        << ", event no "
+        << evt->getEventNumber() ) ;
+        
+      // n usec to sleep within the task
+      int t = (rand() / (float) RAND_MAX) * 1000000 ;
+      usleep( t ) ;
+    }, event)) ;
+  }
+  
+  void waitForAll() {
+    SAFE_PRINT( "waitForAll()" ) ;
+    for ( unsigned int i=0 ; i<_futures.size() ; ++i ) {
+      _futures.at(i).get();
+    }
+    _futures.clear();
+  }
+  
+private:
+  
+  void processFinishedTasks() {
+    auto iter = _futures.begin() ;
+    while ( iter != _futures.end() ) {
+      auto status = iter->wait_for( std::chrono::seconds(0) ) ;
+      if ( status == std::future_status::ready ) {
+        // process finished task and remove it for the pending task list
+        iter->get();
+        iter = _futures.erase( iter );
+      }
+      else {
+        iter++ ;        
+      }
+    }
+  }
+  
+  bool canStartNewTask() const {
+    return ( _futures.size() < _maxNTasks ) ;
+  }
+  
+  void processEvent( LCEventPtr event ) {
+    startTask( event ) ;
+  }
+  
+  void processRunHeader( LCRunHeaderPtr hdr ) {
+    // Wait for all event task to finish
+    // and then process the new run header
+    waitForAll();
+    UTIL::LCTOOLS::dumpRunHeader( hdr.get() );
+  }
+  
+  void modifyEvent( LCEventPtr ) { /* nop */ }
+  void modifyRunHeader( LCRunHeaderPtr ) { /* nop */ }
+  
+private:
+  unsigned int                   _maxNTasks {} ;
+  future_list                    _futures {} ;     
+};
+
+/** Small utility to dump events in parallel from different files
+ */
+int main(int argc, char** argv ){
+
+    // read file names from command line (only argument) 
+    if( argc < 2) {
+        cout << " start tasks to process events in parallel" << endl << endl;
+        cout << " usage:  lcio_parallel_processing <input-file1> [[input-file2],...]" << endl ;
+        exit(1) ;
+    }
+
+    int nFiles = argc-1 ;
+    std::vector<std::string> inputFiles ;
+
+    for(int i=1 ; i <= nFiles ; i++) {
+        inputFiles.push_back( argv[i] )  ;
+    }
+    
+    // The LCReader to read events and runs
+    MT::LCReader reader( MT::LCReader::directAccess ) ;
+    reader.open( inputFiles );
+    
+    unsigned int nThreads = std::thread::hardware_concurrency() ;
+    char *nthreadsenv = getenv( "LCIO_MAX_THREADS" ) ;
+    if ( nthreadsenv ) {
+      nThreads = atoi( nthreadsenv );
+      if ( nThreads <= 0 ) {
+        nThreads = 1;
+      }
+    }
+    
+    // The task scheduler
+    Scheduler scheduler (nThreads);
+    MT::LCReaderListenerList listeners ;
+    listeners.insert( &scheduler ) ;
+    
+    // Read stream and process events and run headers
+    while (1) {
+      try {
+        reader.readNextRecord( listeners );        
+      }
+      catch ( IO::EndOfDataException ) {
+        break;
+      }
+    }
+
+    return 0 ;
+}
+
+

--- a/src/cpp/src/MT/LCReader.cc
+++ b/src/cpp/src/MT/LCReader.cc
@@ -1,0 +1,501 @@
+#include "MT/LCReader.h" 
+
+// -- lcio headers
+#include "SIO/LCSIO.h" 
+#include "SIO/SIOParticleHandler.h"
+#include "SIO/LCIORecords.h"
+#include "SIO/LCIORandomAccessMgr.h"
+#include "IOIMPL/LCEventIOImpl.h"
+#include "IOIMPL/LCRunHeaderIOImpl.h"
+
+// -- sio headers
+#include "SIO_stream.h" 
+#include "SIO_record.h" 
+
+// -- std headers
+#include <assert.h>
+#include <climits>
+
+typedef EVENT::long64 long64 ;
+ 
+namespace MT {
+  
+  LCReader::LCReader( int lcReaderFlag ) :
+    _readEventMap( lcReaderFlag & LCReader::directAccess ),
+    _lcioRecords(std::make_shared<SIO::LCIORecords>()),
+    _raMgr(std::make_shared<SIO::LCIORandomAccessMgr>()) {
+    /* nop */
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  void LCReader::open( const std::string& filename ) {
+    _stream = std::make_shared<sio::stream>();
+    _stream->set_reserve(64 * SIO_KBYTE);
+    // Open the stream
+    auto status = _stream->open( filename, SIO_MODE_READ ) ;
+    if( status != SIO_STREAM_SUCCESS ) {
+      throw IO::IOException( std::string( "[MT::LCReader::open()] Can't open stream: " + filename ) ) ;
+    }
+    if( _readEventMap ) {
+      getEventMap() ;
+    }
+    // We are in single file mode ...
+    if( _myFilenames.empty() ) {
+      _myFilenames.push_back( filename ) ;
+    }
+  }
+  
+  //----------------------------------------------------------------------------
+
+  void LCReader::open( const std::vector<std::string>& filenames ) {
+    if( filenames.empty() ) {
+      throw IO::IOException( "[SIOReader::open()] Provided file list is empty") ;
+    }
+    struct stat fileinfo ;
+    std::string missing_files ;
+    // JE: first we check if all files exist
+    for(unsigned int i=0 ; i < filenames.size(); i++) {
+      if ( FSTAT( filenames[i].c_str(), &fileinfo ) != 0 ) {
+         missing_files += filenames[i] ;
+         missing_files += "  " ;
+      }
+    }
+    // JE: if not raise IOException
+    if( missing_files.size() != 0 ) {
+      throw IO::IOException( std::string( "[MT::LCReader::open()] File(s) not found:  " + missing_files )) ;
+    }
+    _myFilenames = filenames ;
+    _currentFileIndex = 0 ;
+    open( _myFilenames[0] ) ;
+  }
+  
+  //----------------------------------------------------------------------------
+
+  LCRunHeaderPtr LCReader::readNextRunHeader( int accessMode ) {
+    IOIMPL::LCRunHeaderIOImpl* runptr = nullptr ;
+    auto runRecord = _lcioRecords->createRunRecord( &runptr ) ;
+    sio::record_read_result readResult ;
+    // this might throw exceptions
+    try {
+      readRecord( {{runRecord->name(), runRecord}} , readResult ) ;
+    }
+    catch(IO::EndOfDataException) {
+      if ( nullptr != runptr ) {
+        delete runptr ;
+      }
+      return 0 ;
+    }
+    // set the proper acces mode before returning the run
+    if( nullptr != runptr ) {
+      runptr->setReadOnly( accessMode == EVENT::LCIO::READ_ONLY ) ;
+    }
+    // save the current file name in run header parameter: 
+    runptr->parameters().setValue( "LCIOFileName" ,  _myFilenames[ _currentFileIndex  ] ) ;
+    return LCRunHeaderPtr( runptr ) ;
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  LCEventPtr LCReader::readNextEvent( int accessMode )  {
+    IOIMPL::LCEventIOImpl* evtptr = nullptr ;
+    sio::record_read_result readResult ;
+    auto headerRecord = _lcioRecords->createEventHeaderRecord( &evtptr, _readCollectionNames ) ;
+    try {
+      readRecord( {{headerRecord->name(), headerRecord}} , readResult ) ;
+    }
+    catch(IO::EndOfDataException) {
+      if ( nullptr != evtptr ) {
+        delete evtptr ;
+      }
+      return 0 ;
+    }
+    // Create the record to be read. This also setup the collections to be read
+    auto eventRecord = _lcioRecords->createEventRecord( &evtptr ) ;
+    try {
+      readRecord( {{eventRecord->name(), eventRecord}} , readResult ) ;
+    }
+    catch(IO::EndOfDataException) {
+      if ( nullptr != evtptr ) {
+        delete evtptr ;
+      }
+      return 0 ;
+    }
+    // Set the proper acces mode before returning the event
+    evtptr->setAccessMode( accessMode ) ;
+    postProcessEvent(evtptr) ;
+    return LCEventPtr(evtptr) ;
+  }
+  
+  //----------------------------------------------------------------------------
+
+  int LCReader::getNumberOfEvents()  {
+    // create the event map if needed (i.e. not opened in direct access mode)
+    if( ! _readEventMap ) {
+      _readEventMap = true ;      
+      getEventMap() ;
+    }
+    return _raMgr->getEventMap().getNumberOfEventRecords()  ;    
+  }
+  
+  //----------------------------------------------------------------------------
+
+  int LCReader::getNumberOfRuns() {
+    // create the event map if needed (i.e. not opened in direct access mode)
+    if( ! _readEventMap ){  
+      _readEventMap = true ;
+      getEventMap() ;
+    }
+    return _raMgr->getEventMap().getNumberOfRunRecords() ;
+  }
+  
+  //----------------------------------------------------------------------------
+
+  void LCReader::getRuns(EVENT::IntVec & runs) {
+    int nRun = this->getNumberOfRuns() ;    
+    runs.resize( nRun ) ;
+    auto map = _raMgr->getEventMap() ;
+    auto it = map.begin() ;   
+    
+    for(int i=0 ; i <nRun ; ++i, ++it) {
+      runs[i] = it->first.RunNum ;
+      assert(  it->first.EvtNum  == -1 ) ;
+    }
+  }
+
+  //----------------------------------------------------------------------------
+
+  void LCReader::getEvents(EVENT::IntVec & events) {
+    int nRun = this->getNumberOfRuns() ;
+    int nEvt = this->getNumberOfEvents() ;
+    events.resize(  2 * nEvt ) ;
+    auto map = _raMgr->getEventMap() ;
+    auto it = map.begin() ;   
+    // This line should be equivalent to the one commented after
+    std::advance( it, nRun );
+    // for(int i=0 ; i <nRun ; ++i , ++it ) ;
+    for(int i=0 ; i < nEvt ; ++i , ++it ) {
+      events[ 2*i     ] = it->first.RunNum ;
+      events[ 2*i + 1 ] = it->first.EvtNum ;
+      assert( it->first.EvtNum   != -1 ) ; 
+    }
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  void LCReader::setReadCollectionNames( const std::vector<std::string>& colnames ) {
+    _readCollectionNames = colnames ;
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  void LCReader::skipNEvents( int n ) {     
+    if( n < 1 ) { // nothing to skip
+      return ;
+    }
+    int eventsSkipped = 0 ;
+    sio::record_read_result readResult ;
+    IOIMPL::LCEventIOImpl* evtptr = nullptr ;
+    auto headerRecord = _lcioRecords->createEventHeaderRecord( &evtptr, _readCollectionNames ) ;
+    while( eventsSkipped++ < n ) {
+      try {
+        readRecord( {{headerRecord->name(), headerRecord}} , readResult ) ;
+      }
+      catch(IO::EndOfDataException) {
+        if ( nullptr != evtptr ) {
+          delete evtptr ;
+        }
+        return ;
+      }
+    }
+    // Create the record to be read. This also setup the collections to be read
+    // WARNING evtptr is first deleted when calling readRecord
+    auto eventRecord = _lcioRecords->createEventRecord( &evtptr ) ;
+    try {
+      readRecord( {{eventRecord->name(), eventRecord}} , readResult ) ;
+    }
+    catch(IO::EndOfDataException) {
+      if ( nullptr != evtptr ) {
+        delete evtptr ;
+      }
+      return ;
+    }
+    if ( nullptr != evtptr ) {
+      delete evtptr ;
+    }
+  }
+  
+  //----------------------------------------------------------------------------
+
+  LCRunHeaderPtr LCReader::readRunHeader( int runNumber, int accessMode ) {
+    if( _readEventMap ) {
+      EVENT::long64 pos = _raMgr->getPosition( SIO::RunEvent( runNumber, -1 ) ) ; 
+      if( pos != SIO::RunEventMap::npos ) {
+        int status = _stream->seek( pos ) ;
+        if( status != SIO_STREAM_SUCCESS ) { 
+            throw IO::IOException( std::string( "[SIOReader::readRunHeader()] Can't seek stream to"
+            " requested position" ) ) ;
+        }
+        return readNextRunHeader( accessMode ) ;
+      }
+      else {
+        return nullptr ;
+      }
+    } 
+    else {  // no event map ------------------
+      std::cout << " WARNING : LCReader::readRunHeader(run,mode) called but not in direct access Mode  - " << std::endl 
+                << " Too avoid this WARNING create the LCReader with: " << std::endl 
+                << "       auto r = new MT::LCReader( MT::LCReader::directAccess ) ; " << std::endl ;
+    }
+    return nullptr ;
+  }
+  
+  //----------------------------------------------------------------------------
+
+  LCEventPtr LCReader::readEvent( int runNumber, int evtNumber, int accessMode ) {
+    if( _readEventMap ) {
+      EVENT::long64 pos = _raMgr->getPosition( SIO::RunEvent( runNumber, evtNumber ) ) ; 
+      if( pos != SIO::RunEventMap::npos ) {	
+	      int status = _stream->seek( pos ) ;
+	      if( status != SIO_STREAM_SUCCESS ) { 
+	        throw IO::IOException( std::string( "[SIOReader::readEvent()] Can't seek stream to"
+					  " requested position" ) ) ;
+        }
+	      return readNextEvent( accessMode ) ;
+      } 
+      else {
+	      return 0 ;
+      }
+    } 
+    else {  // no event map ------------------
+      std::cout << " WARNING : LCReader::readEvent(run,evt) called but not in direct access Mode  - " << std::endl 
+		            << " use fast skip mechanism instead ..." << std::endl 
+		            << " Too avoid this WARNING create the LCReader with: " << std::endl 
+		            << "       auto r = new MT::LCReader( MT::LCReader::directAccess ) ; " << std::endl ;
+      // ---- OLD code with fast skip -----------
+      bool runFound = false ;
+      bool evtFound = false ;
+      // skip through run headers until run found or EOF
+      while ( ! runFound ) {
+        auto run = readNextRunHeader() ;
+	      if( nullptr == run ) break ; 
+	      runFound = ( run->getRunNumber() == runNumber ) ;
+      }
+      if( !runFound ) {
+	      return 0 ;
+      }
+      // Read event header until we find the requested event number
+      sio::record_read_result readResult;
+      IOIMPL::LCEventIOImpl* evtptr = nullptr ;
+      auto headerRecord = _lcioRecords->createEventHeaderRecord( &evtptr, _readCollectionNames ) ;
+      while( ! evtFound ) {
+        try {
+          readRecord( {{headerRecord->name(), headerRecord}} , readResult ) ;
+        }
+        catch(IO::EndOfDataException) {
+          if ( nullptr != evtptr ) {
+            delete evtptr ;
+          }
+          return 0 ;
+        }
+        evtFound = ( evtptr->getEventNumber() == evtNumber ) ;
+      }
+      if( !evtFound ) {
+        if ( nullptr != evtptr ) {
+          delete evtptr ;
+        }
+        return 0 ;
+      }
+      // Create the record to be read. This also setup the collections to be read
+      auto eventRecord = _lcioRecords->createEventRecord( &evtptr ) ;
+      try {
+        readRecord( {{eventRecord->name(), eventRecord}} , readResult ) ;
+      }
+      catch(IO::EndOfDataException) {
+        if ( nullptr != evtptr ) {
+          delete evtptr ;
+        }
+        return 0 ;
+      }
+      evtptr->setAccessMode( EVENT::LCIO::READ_ONLY ) ;
+      postProcessEvent(evtptr) ;
+      return LCEventPtr( evtptr ) ;  
+    } //-- end fast skip
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  void LCReader::close() {
+    _raMgr->clear() ;
+    _readEventMap = false ;
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  void LCReader::readStream( const LCReaderListenerList & listeners ) {
+    readStream( listeners, INT_MAX ) ;
+  }
+  
+  //----------------------------------------------------------------------------
+
+  void LCReader::readStream( const LCReaderListenerList & listeners, int maxRecord ) {
+    const bool readUntilEOF = (maxRecord == INT_MAX) ;
+    // here we need to read all the records on the stream
+    // and then notify the listeners depending on the type ....
+    // set all known records to unpack
+    // read records and notify listeners
+    int recordsRead = 0 ;
+    sio::record_read_result readResult;
+    while( recordsRead < maxRecord ) {
+      IOIMPL::LCEventIOImpl* evtptr = nullptr ;
+      IOIMPL::LCRunHeaderIOImpl* runptr = nullptr ;
+      auto runRecord = _lcioRecords->createRunRecord( &runptr ) ;
+      auto headerRecord = _lcioRecords->createEventHeaderRecord( &evtptr, _readCollectionNames ) ;
+      sio::record_map records = {
+        {runRecord->name(), runRecord} , 
+        {headerRecord->name(), headerRecord}
+      };
+      try {
+        readRecord( records , readResult ) ;
+      }
+      catch(IO::EndOfDataException) {
+        if ( nullptr != evtptr ) {
+          delete evtptr ;
+        }
+        if ( nullptr != runptr ) {
+          delete runptr ;
+        }
+        // only throw exception if a 'finite' number of records was 
+        // specified that couldn't be read from the file
+        if( readUntilEOF ) {
+          return ;
+        }
+        else {
+          std::stringstream message ;
+          message << "SIOReader::readStream(int maxRecord) : EOF before " 
+            << maxRecord << " records read from file" << std::ends ;
+          throw IO::EndOfDataException( message.str())  ;
+        }
+      }
+      // Next record is an event. Setup the record and read it
+      if( readResult._record->name() == LCSIO_HEADERRECORDNAME ) {
+        auto eventRecord = _lcioRecords->createEventRecord( &evtptr ) ;
+        try {
+          readRecord( {{eventRecord->name(), eventRecord}} , readResult ) ;
+        }
+        catch(IO::EndOfDataException) {
+          if ( nullptr != evtptr ) {
+            delete evtptr ;
+          }
+          if ( nullptr != runptr ) {
+              delete runptr ;
+          }
+          // only throw exception if a 'finite' number of records was 
+          // specified that couldn't be read from the file
+          if( readUntilEOF ) {
+            return ;
+          }
+          else {
+            std::stringstream message ;
+            message << "SIOReader::readStream(int maxRecord) : EOF before " 
+              << maxRecord << " records read from file" << std::ends ;
+            throw IO::EndOfDataException( message.str())  ;
+          }
+        }
+      }
+      // notify LCRunListeners
+      if( readResult._record->name() == LCSIO_RUNRECORDNAME ) {
+        recordsRead++ ;
+        LCRunHeaderPtr hdrsptr( runptr ) ;
+        auto iter = listeners.begin() ;
+        while( iter != listeners.end() ) {
+          runptr->setReadOnly( false ) ;
+          (*iter)->modifyRunHeader( hdrsptr ) ;
+          runptr->setReadOnly( true ) ;
+          (*iter)->processRunHeader( hdrsptr ) ;          
+          iter++ ;
+        }
+      }
+      // notify LCEventListeners 
+      if( readResult._record->name() == LCSIO_EVENTRECORDNAME ) {
+        recordsRead++ ;
+        LCEventPtr evtsptr( evtptr ) ;
+        auto iter = listeners.begin() ;
+        while( iter != listeners.end() ) {
+          postProcessEvent(evtptr) ;
+          // fg20070813 changed order of update and process (needed for 
+          // Marlin modifying processors )
+          evtptr->setAccessMode( EVENT::LCIO::UPDATE ) ;
+          (*iter)->modifyEvent( evtsptr ) ;
+          evtptr->setAccessMode( EVENT::LCIO::READ_ONLY ) ; // set the proper acces mode
+          (*iter)->processEvent( evtsptr ) ;
+          iter++ ;    
+        }
+      }
+    }
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  void LCReader::readNextRecord( const LCReaderListenerList & listeners ) {
+    readStream( listeners, 1 );
+  }
+  
+  //----------------------------------------------------------------------------
+
+  void LCReader::readRecord( const sio::record_map &records , sio::record_read_result &readResult ) {
+    if( _stream->state() == SIO_STATE_OPEN ) {
+      // read the next record from the stream
+      readResult = _stream->read_next_record( records ) ;
+      if( ! (readResult._status & 1) ) {
+        if( readResult._status & SIO_STREAM_EOF ) {
+          // if we have a list of filenames open the next file
+          if( !_myFilenames.empty()  && _currentFileIndex+1 < _myFilenames.size() ) {
+            close() ;
+            open( _myFilenames[ ++_currentFileIndex  ] ) ;
+            readRecord( records, readResult ) ;
+            return ;
+          }
+          throw IO::EndOfDataException("EOF") ;
+        }
+        throw IO::IOException( std::string(" io error on stream: ") + _stream->file_name() ) ;
+      }
+    }
+    else {
+      throw IO::IOException( " stream not opened" ) ;
+    }
+  }
+  
+  //----------------------------------------------------------------------------
+
+  void LCReader::postProcessEvent( EVENT::LCEvent *evt ) {
+    // restore the daughter relations from the parent relations
+    SIO::SIOParticleHandler::restoreParentDaughterRelations( evt ) ;
+    // check subset collection's pointers
+    char* rColChar = getenv ("LCIO_IGNORE_NULL_IN_SUBSET_COLLECTIONS") ;
+    if( nullptr != rColChar ) {
+      return;
+    }
+    const std::vector< std::string >* strVec = evt->getCollectionNames() ;
+    for( auto name = strVec->begin() ; name != strVec->end() ; name++) {
+      EVENT::LCCollection* col = evt->getCollection( *name ) ;
+      if( col->isSubset() ) {
+        for( int i=0,N=col->getNumberOfElements() ; i<N ; ++i ) {
+          if( col->getElementAt( i ) == 0 ) {
+            std::stringstream sts ;
+            sts << " SIOReader::postProcessEvent: null pointer in subset collection " 
+                << *name << " at position: " << i  << std::endl ;
+            throw EVENT::Exception( sts.str()  ) ;
+          }
+        }
+      }
+    }
+  }
+  
+  //----------------------------------------------------------------------------
+  
+  void LCReader::getEventMap() {
+    _raMgr->createEventMap( _stream.get() ) ;
+  }
+
+} // namespace


### PR DESCRIPTION
BEGINRELEASENOTES
- Implemented `MT::LCReader` for multi-threading usage
    - Uses `std::shared_ptr` to manage LCEvent and LCRunHeader after record reading
    - Can read records one by one using `readNextRecord()`
    - Listeners are directly pass in `readStream()` as argument to avoid possible late registration of additional listeners
- Added example for parallel processing with MT::LCReader
   - Simple scheduler to run task in parallel over n events
   - Join event processing task on run header callback
   - Can specify max number of threads N to use with:
```shell
export LCIO_MAX_THREADS=N
```

ENDRELEASENOTES