### PR TITLE
Remove deprecated set_unexpected and set_terminate

### DIFF
--- a/src/cpp/src/IMPL/LCIOExceptionHandler.cc
+++ b/src/cpp/src/IMPL/LCIOExceptionHandler.cc
@@ -29,11 +29,7 @@ void lcio_unexpected(){
   }
 }
 
-  LCIOExceptionHandler::LCIOExceptionHandler(){
-      
-    std::set_unexpected( lcio_unexpected ) ;
-    std::set_terminate( lcio_unexpected ) ;
-  }
+  LCIOExceptionHandler::LCIOExceptionHandler(){}
     
 
   LCIOExceptionHandler* LCIOExceptionHandler::createInstance(){


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove `std::set_unexpected` and `std::set_terminate` which were removed in C++17

ENDRELEASENOTES