### PR TITLE
re-introduce set_terminate in LCIOExceptionHandler

### DIFF
--- a/src/cpp/src/IMPL/LCIOExceptionHandler.cc
+++ b/src/cpp/src/IMPL/LCIOExceptionHandler.cc
@@ -29,7 +29,9 @@ void lcio_unexpected(){
   }
 }
 
-  LCIOExceptionHandler::LCIOExceptionHandler(){}
+  LCIOExceptionHandler::LCIOExceptionHandler(){
+    std::set_terminate( lcio_unexpected ) ;
+  }
     
 
   LCIOExceptionHandler* LCIOExceptionHandler::createInstance(){


### PR DESCRIPTION

BEGINRELEASENOTES
- re-introduce `std::set_terminate` in `LCIOExceptionHandler`, which is not deprecated in c++17
 

ENDRELEASENOTES