### PR TITLE
Fix operator in EVENT/UTIL namespaces

### DIFF
--- a/src/cpp/include/UTIL/Operators.h
+++ b/src/cpp/include/UTIL/Operators.h
@@ -80,75 +80,75 @@ namespace UTIL{
   const std::string& header(const EVENT::Vertex *);
   const std::string& tail(const EVENT::Vertex *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::Vertex>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::Vertex &v);
+  
 
 
 //hauke 2010 (start)
   const std::string& header( const EVENT::MCParticle *);
   const std::string& tail( const EVENT::MCParticle *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::MCParticle>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::MCParticle &);
+  
 
 
   const std::string& header( const EVENT::TrackerHit *);
   const std::string& tail( const EVENT::TrackerHit *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::TrackerHit>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHit &);
+
 
   const std::string& header( const EVENT::TrackerHitPlane *);
   const std::string& tail( const EVENT::TrackerHitPlane *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::TrackerHitPlane>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitPlane &);
+  
 
   const std::string& header( const EVENT::TrackerHitZCylinder *);
   const std::string& tail( const EVENT::TrackerHitZCylinder *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::TrackerHitZCylinder>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitZCylinder &);
+  
 
   const std::string& header( const EVENT::SimTrackerHit *);
   const std::string& tail( const EVENT::SimTrackerHit *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::SimTrackerHit>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::SimTrackerHit &);
+  
 
   const std::string& header( const EVENT::CalorimeterHit *);
   const std::string& tail( const EVENT::CalorimeterHit *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::CalorimeterHit>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::CalorimeterHit &);
+  
 
   const std::string& header( const EVENT::SimCalorimeterHit *);
   const std::string& tail( const EVENT::SimCalorimeterHit *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::SimCalorimeterHit>& sV);
-  std::ostream& operator<<( std::ostream& out, const EVENT::SimCalorimeterHit &);
 
+  
   const std::string& header( const EVENT::ReconstructedParticle *);
   const std::string& tail( const EVENT::ReconstructedParticle *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::ReconstructedParticle> & );
-  std::ostream& operator<<( std::ostream& out, const EVENT::ReconstructedParticle &);
+  
 
   const std::string& header( const EVENT::Track *);
   const std::string& tail( const EVENT::Track *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::Track> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::Track &);
+  
 
   const std::string& header( const EVENT::TrackState *);
   const std::string& tail( const EVENT::TrackState *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::TrackState> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::TrackState &);
+  
 
   const std::string& header( const EVENT::Cluster *);
   const std::string& tail( const EVENT::Cluster *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::Cluster> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::Cluster &);
+  
 
   const std::string& header( const EVENT::LCRelation *);
   const std::string& tail( const EVENT::LCRelation *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCRelation> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCRelation &);
+  
 
   const std::string& header( const EVENT::LCFloatVec *);
   const std::string& tail( const EVENT::LCFloatVec *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCFloatVec> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCFloatVec &);
+  
 
   template <class T> 
         const std::string & header(){return header((T*)(0)); }
@@ -194,42 +194,42 @@ namespace UTIL{
   const std::string& header( const EVENT::LCCollection *);
   const std::string& tail( const EVENT::LCCollection *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCCollection> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCCollection &);
+  
 
   const std::string& header( const EVENT::LCEvent *);
   const std::string& tail( const EVENT::LCEvent *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCEvent> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCEvent &);
+  
 
   const std::string& header( const EVENT::LCFlag *);
   const std::string& tail( const EVENT::LCFlag *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCFlag> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCFlag &);
+  
 
   const std::string& header( const EVENT::LCGenericObject *, const EVENT::LCCollection *v = NULL);
   const std::string& tail( const EVENT::LCGenericObject *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCGenericObject> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCGenericObject &);
+  
 
   const std::string& header( const EVENT::LCIntVec *);
   const std::string& tail( const EVENT::LCIntVec *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCIntVec> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCIntVec &);
+  
 
   const std::string& header( const EVENT::LCObject *);
   const std::string& tail( const EVENT::LCObject *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCObject> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCObject &);
+  
 
   const std::string& header( const EVENT::LCParameters *);
   const std::string& tail( const EVENT::LCParameters *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCParameters> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCParameters &);
+  
 
   const std::string& header( const EVENT::LCRunHeader *);
   const std::string& tail( const EVENT::LCRunHeader *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCRunHeader> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCRunHeader &);
+  
 
 /*
   const std::string& header( const EVENT::LCStrVec &);
@@ -241,12 +241,12 @@ namespace UTIL{
   const std::string& header( const EVENT::ParticleID *);
   const std::string& tail( const EVENT::ParticleID *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::ParticleID> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::ParticleID &);
+  
 
   const std::string& header( const EVENT::RawCalorimeterHit *);
   const std::string& tail( const EVENT::RawCalorimeterHit *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::RawCalorimeterHit> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::RawCalorimeterHit &);
+  
 
 //  const std::string& header( const EVENT::TPCHit &);
 //  const std::string& tail( const EVENT::TPCHit &);
@@ -256,22 +256,22 @@ namespace UTIL{
   const std::string& header( const EVENT::TrackerData *);
   const std::string& tail( const EVENT::TrackerData *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::TrackerData> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerData &);
+  
 
   const std::string& header( const EVENT::TrackerPulse *);
   const std::string& tail( const EVENT::TrackerPulse *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::TrackerPulse> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerPulse &);
+  
 
   const std::string& header( const EVENT::TrackerRawData *);
   const std::string& tail( const EVENT::TrackerRawData *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::TrackerRawData> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerRawData &);
+  
 
   const std::string& header( const EVENT::LCIO *);
   const std::string& tail( const EVENT::LCIO *);
   std::ostream& operator<<( std::ostream& out, const UTIL::lcio_short<EVENT::LCIO> &);
-  std::ostream& operator<<( std::ostream& out, const EVENT::LCIO &);
+  
 
 
 
@@ -292,5 +292,40 @@ namespace UTIL{
   }
 
 }//namespace
+
+// rete, 2019: Move stream operator overloads of EVENT
+// objects in namespace EVENT, where they should be ...
+// see: https://stackoverflow.com/questions/3623631/where-should-non-member-operator-overloads-be-placed
+namespace EVENT {
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::Vertex &v);
+  std::ostream& operator<<( std::ostream& out, const EVENT::MCParticle &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHit &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitPlane &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitZCylinder &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::SimTrackerHit &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::CalorimeterHit &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::ReconstructedParticle &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::SimCalorimeterHit &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::Track &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackState &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::Cluster &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCRelation &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCFloatVec &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCCollection &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCEvent &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCFlag &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCGenericObject &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCIntVec &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCObject &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCParameters &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCRunHeader &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::ParticleID &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::RawCalorimeterHit &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerData &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerPulse &);  
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerRawData &);
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCIO &);
+}
 
 #endif /* ifndef LCIO_OPERATORS_H */

--- a/src/cpp/src/UTIL/Operators.cc
+++ b/src/cpp/src/UTIL/Operators.cc
@@ -134,13 +134,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCCollection &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # LCEvent
@@ -204,13 +197,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCEvent  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # LCFlag
@@ -255,14 +241,6 @@ namespace UTIL{
         out << setw(30) << setfill(' ') << left << "Flag" << right << hex << setw(40) << hit->getFlag() << dec << endl;
         return out;
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCFlag  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # LCGenericObject
@@ -338,14 +316,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCGenericObject  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
     //============================================================================
     //   # LCIntVec
     //============================================================================
@@ -402,13 +372,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCIntVec  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # LCFloatVec
@@ -463,14 +426,6 @@ namespace UTIL{
 
         return out;
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCFloatVec &v){
-        out << lcio_long(v,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # LCStrVec
@@ -575,14 +530,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCObject  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
     //============================================================================
     //   # LCParameters
     //============================================================================
@@ -683,14 +630,6 @@ namespace UTIL{
 
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCParameters  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
     //============================================================================
     //   # LCRelation
     //============================================================================
@@ -737,14 +676,6 @@ namespace UTIL{
 
         return out;
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCRelation &v){
-        out << lcio_long(v,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # LCRunHeader
@@ -797,14 +728,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCRunHeader  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
     //============================================================================
     //   # LCIO
     //============================================================================
@@ -847,14 +770,6 @@ namespace UTIL{
         //print object attributs
         return out;
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::LCIO  &hit){ //hauke
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # ParticleID
@@ -905,14 +820,6 @@ namespace UTIL{
         out << setw(30) << setfill(' ') << left << "Algorithm type"<< setfill(' ') << right << setw(40) << dec << hit->getAlgorithmType() << endl;
         return out;
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::ParticleID  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # RawCalorimeterHit
@@ -979,14 +886,6 @@ namespace UTIL{
         out << setw(30) << setfill(' ') << left << "TimeStamp"<< setfill(' ') << right << setw(40) << dec << hit->getTimeStamp() << endl;
         return out;
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::RawCalorimeterHit  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # TPCHit (deprecated)
@@ -1110,14 +1009,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::TrackerData  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
     //============================================================================
     //   # TrackerPulse
     //============================================================================
@@ -1195,14 +1086,6 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::TrackerPulse  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
     //============================================================================
     //   # TrackerRawData
     //============================================================================
@@ -1268,15 +1151,6 @@ namespace UTIL{
         out << setw(30) << setfill(' ') << left << "Time"<< setfill(' ') << right << setw(40) << dec << hit->getTime() << endl;
         return out;
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::TrackerRawData  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
 
     //============================================================================
     //   # SimCalorimeterHit
@@ -1423,14 +1297,6 @@ namespace UTIL{
         return(out);
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::SimCalorimeterHit  &hit){
-        out<<lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
-
     //============================================================================
     //   # TrackerHit
     //============================================================================
@@ -1536,14 +1402,6 @@ namespace UTIL{
 
         return(out);
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHit &hit){ //hauke
-        out << lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # TrackerHitPlane
@@ -1664,13 +1522,6 @@ namespace UTIL{
         return(out);
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitPlane &hit){
-        out << lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
     //============================================================================
     //   # TrackerHitZCylinder
     //============================================================================
@@ -1789,14 +1640,6 @@ namespace UTIL{
 
         return(out);
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitZCylinder &hit){
-        out << lcio_long(hit,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # SimTrackerHit
@@ -1962,14 +1805,6 @@ namespace UTIL{
         return(out);
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::SimTrackerHit &hit){ //hauke
-        out << lcio_long(hit,NULL);
-        return(out);
-    }
-
-
-
-
     //============================================================================
     //   # CalorimeterHit
     //============================================================================
@@ -2071,17 +1906,6 @@ namespace UTIL{
 
         return(out);
     }
-
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::CalorimeterHit &hit){ //hauke
-        out << lcio_long(hit,NULL);
-        //out << lcio_long(a,NULL);
-
-        return(out);
-    }
-
-
-
 
     //============================================================================
     //   # MCParticle
@@ -2242,14 +2066,6 @@ namespace UTIL{
         << endl ;
         }
      */
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::MCParticle &mcp){ //hauke
-        out << lcio_long(mcp,NULL);
-        return out;
-    }
-
-
-
 
     //============================================================================
     //   # ReconstructedParticle
@@ -2486,14 +2302,6 @@ namespace UTIL{
         return(out);
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::ReconstructedParticle &part){ //hauke
-        out << lcio_long(part,NULL);
-        return(out);
-    }
-
-
-
-
     //============================================================================
     //   # TrackState
     //============================================================================
@@ -2606,14 +2414,6 @@ namespace UTIL{
         out << noshowpos;
         return(out);
     }
-
-    std::ostream& operator<<( std::ostream& out, const EVENT::TrackState &part){
-        out << lcio_long(part,NULL);
-        return(out);
-    }
-
-
-
 
     //============================================================================
     //   # Track
@@ -2810,14 +2610,6 @@ namespace UTIL{
         return(out);
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::Track &part){ //hauke
-        out << lcio_long(part,NULL);
-        return(out);
-    }
-
-
-
-
     //============================================================================
     //   # Cluster
     //============================================================================
@@ -2957,14 +2749,6 @@ namespace UTIL{
         return(out);
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::Cluster &clu){ //hauke
-        out << lcio_long(clu,NULL);
-        return(out);
-    }
-
-
-
-
     //============================================================================
     //   # Vertex
     //============================================================================
@@ -3051,11 +2835,151 @@ namespace UTIL{
         return out;
     }
 
-    std::ostream& operator<<( std::ostream& out, const EVENT::Vertex &v){
-        out << lcio_long(v,NULL);
-        return out;
-    }
-
-
 } // namespace
 
+using namespace UTIL ;
+
+// see header file for namespace change here
+namespace EVENT {
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCCollection &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCEvent  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCFlag  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCGenericObject  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCIntVec  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCFloatVec &v){
+    out << lcio_long(v,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCObject  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCParameters  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCRelation &v){
+    out << lcio_long(v,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCRunHeader  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::LCIO  &hit){ //hauke
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::ParticleID  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::RawCalorimeterHit  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerData  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerPulse  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerRawData  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::SimCalorimeterHit  &hit){
+    out<<lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHit &hit){ //hauke
+    out << lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitPlane &hit){
+    out << lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackerHitZCylinder &hit){
+    out << lcio_long(hit,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::SimTrackerHit &hit){ //hauke
+    out << lcio_long(hit,NULL);
+    return(out);
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::CalorimeterHit &hit){ //hauke
+    out << lcio_long(hit,NULL);
+    return(out);
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::MCParticle &mcp){ //hauke
+    out << lcio_long(mcp,NULL);
+    return out;
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::ReconstructedParticle &part){ //hauke
+    out << lcio_long(part,NULL);
+    return(out);
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::TrackState &part){
+    out << lcio_long(part,NULL);
+    return(out);
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::Track &part){
+    out << lcio_long(part,NULL);
+    return(out);
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::Cluster &clu){ //hauke
+    out << lcio_long(clu,NULL);
+    return(out);
+  }
+
+  std::ostream& operator<<( std::ostream& out, const EVENT::Vertex &v){
+    out << lcio_long(v,NULL);
+    return out;
+  }  
+  
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Moved all stream operator overloads of EVENT class types into EVENT namespace (moved out from UTIL namespace)
ENDRELEASENOTES