### PR TITLE
fix building for MacOS 10.14

### DIFF
--- a/src/cpp/src/UTIL/lXDR.cc
+++ b/src/cpp/src/UTIL/lXDR.cc
@@ -10,10 +10,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(__APPLE_CC__)
-#include "/usr/include/sys/types.h"
-#endif
-
 #if defined(__linux) || defined(__CYGWIN__) || defined(__APPLE_CC__)
 #include <netinet/in.h>
 #endif


### PR DESCRIPTION

BEGINRELEASENOTES
- fix building for MacOS 10.14
    - rm superfluous `#include "/usr/include/sys/types.h"` 
       (thanks P.Mato)      

ENDRELEASENOTES