### PR TITLE
Install CMake files in standard directory to be found by CMake

### DIFF
--- a/cmake/MacroGeneratePackageConfigFiles.cmake
+++ b/cmake/MacroGeneratePackageConfigFiles.cmake
@@ -9,7 +9,7 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION cmake )
                 #IF( EXISTS "${_current_dir}/MacroCheckPackageLibs.cmake" )
                 #    INSTALL( FILES "${_current_dir}/MacroCheckPackageLibs.cmake" DESTINATION cmake )
                 #ENDIF()
@@ -26,7 +26,7 @@ MACRO( GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION cmake )
                 #IF( EXISTS "${_current_dir}/MacroCheckPackageVersion.cmake" )
                 #    INSTALL( FILES "${_current_dir}/MacroCheckPackageVersion.cmake" DESTINATION cmake )
                 #ENDIF()


### PR DESCRIPTION
Currently LCIO cannot easily be used from its LCG installation due to wrongly placed CMake configurations: https://sft.its.cern.ch/jira/browse/SPI-1523

This MR fixes it by installing the files in a `cmake` subdirectory of the install target dir.

BEGINRELEASENOTES
- Install CMake configuration files in a standard directory searched by CMake
ENDRELEASENOTES


