### PR TITLE
Update rpaht settings

### DIFF
--- a/cmake/ilcsoft_default_rpath_settings.cmake
+++ b/cmake/ilcsoft_default_rpath_settings.cmake
@@ -1,14 +1,14 @@
-# add library install path to the rpath list
-SET( CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" )
-MARK_AS_ADVANCED( CMAKE_INSTALL_RPATH )
+#  When building, don't use the install RPATH already (but later on when installing)
+set(CMAKE_SKIP_BUILD_RPATH FALSE)         # don't skip the full RPATH for the build tree
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) # use always the build RPATH for the build tree
+set(CMAKE_MACOSX_RPATH TRUE)              # use RPATH for MacOSX
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) # point to directories outside the build tree to the install RPATH
 
-# add install path to the rpath list (apple)
-IF( APPLE )
-    SET( CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" )
-    MARK_AS_ADVANCED( CMAKE_INSTALL_NAME_DIR )
-ENDIF()
-
-# append link pathes to rpath list
-SET( CMAKE_INSTALL_RPATH_USE_LINK_PATH 1 )
-MARK_AS_ADVANCED( CMAKE_INSTALL_RPATH_USE_LINK_PATH )
+set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR}) # install LIBDIR
+set(CMAKE_SKIP_INSTALL_RPATH FALSE)          # don't skip the full RPATH for the install tree
+if(APPLE)
+  set(CMAKE_INSTALL_NAME_DIR "@rpath")
+  set(CMAKE_INSTALL_RPATH "@loader_path/../lib")    # self relative LIBDIR
+  set(CMAKE_SKIP_INSTALL_RPATH FALSE)          # don't skip the full RPATH for the install tree
+endif()
 


### PR DESCRIPTION
BEGINRELEASENOTES
-  Use "Always full RPATH" as as implemented in ROOT

ENDRELEASENOTES
The problem is that the build location is placed into LC_RPATH
```
objdump -x /Users/Shared/cvmfs/sft.cern.ch/lcg/releases/LCIO/02.13-28ace/x86_64-mac1015-clang110-opt/lib/liblcio.2.13.0.dylib
          cmd LC_RPATH
      cmdsize 104
         path /Users/mato/Development/releases/97rc3python3/LCIO/02.13/x86_64-mac1015-clang110-opt/lib (offset 12)
```
but on mac it should be
```
Load command 17
          cmd LC_RPATH
      cmdsize 32
         path @loader_path/../lib (offset 12)
```
all is crucial for LCG releases of mac binaries and downstream key4hep developments.