### PR TITLE
PyROOT fix

### DIFF
--- a/src/python/pyLCIO/base/HandleExceptions.py
+++ b/src/python/pyLCIO/base/HandleExceptions.py
@@ -12,7 +12,7 @@ from sixlcio import reraise
 import inspect, sys, ROOT, pyLCIO
 import pyLCIO.exceptions.Exceptions
 
-# Cope with API change with ROOT version > 6.20
+# Cope with API change with ROOT version >= 6.21
 if ROOT.gROOT.GetVersionCode() >= (6<<16) + (21<<8) :
   from libcppyy import CPPOverload
 else:

--- a/src/python/pyLCIO/base/HandleExceptions.py
+++ b/src/python/pyLCIO/base/HandleExceptions.py
@@ -13,7 +13,7 @@ import inspect, sys, ROOT, pyLCIO
 import pyLCIO.exceptions.Exceptions
 
 # Cope with API change with ROOT version > 6.20
-if ROOT.gROOT.GetVersionCode() > (6<<16) + (20<<8) :
+if ROOT.gROOT.GetVersionCode() >= (6<<16) + (21<<8) :
   from libcppyy import CPPOverload
 else:
   CPPOverload = ROOT.MethodProxy 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fine tune the latest fix to cope with new PyROOT to use old API for versions 6.20.X
ENDRELEASENOTES
resolves #76