### PR TITLE
Improve delphes

### DIFF
--- a/examples/cpp/delphes2lcio/CMakeLists.txt
+++ b/examples/cpp/delphes2lcio/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(ROOT)
 find_package(Delphes)
 
 # build the executable and put it into bin/
-add_executable(DelphesSTDHEP2LCIO ./src/DelphesSTDHEP2LCIO.cpp ./src/DelphesLCIOConverter.cc)
+add_executable(DelphesSTDHEP2LCIO ./src/DelphesSTDHEP2LCIO.cpp ./src/DelphesLCIOConverter.cc ./src/DelphesLCIOConfig.cc)
 target_include_directories(DelphesSTDHEP2LCIO PRIVATE ${DELPHES_INCLUDE_DIRS} ${LCIO_INCLUDE_DIRS} ./include)
 target_link_libraries(DelphesSTDHEP2LCIO ${LCIO_LIBRARIES} ${DELPHES_LIBRARY} ROOT::Core ROOT::RIO ROOT::Tree ROOT::Physics  ROOT::GenVector ROOT::MathCore)
 install(TARGETS DelphesSTDHEP2LCIO DESTINATION bin)

--- a/examples/cpp/delphes2lcio/README.md
+++ b/examples/cpp/delphes2lcio/README.md
@@ -79,7 +79,7 @@ Then you can run Delphes with
 DelphesSTDHEP2LCIO $DELPHES_DIR/cards/delphes_card_ILD.tcl output.slcio input.stdhep
 ```
 
-This creates an LCIO files with the following collections:
+This creates an LCIO files with the following default collections:
 
 
 ```

--- a/examples/cpp/delphes2lcio/README.md
+++ b/examples/cpp/delphes2lcio/README.md
@@ -178,6 +178,9 @@ root [0] .x higgs_recoil_plots_fast.C("../build/E250-TDR_ws.Pe2e2h.Gwhizard-1_95
 ```
 
 
+-----
+
+
 ## Advanced Topics
 
 ### Configuration file
@@ -204,3 +207,15 @@ set Delphes2LCIO_ConfigFileName "../examples/delphes2lcio.cfg"
 
 where the path to the config file has to be either relative from your working directory or preferably
 an absolute path name.
+
+The following maps are required:
+
+- *MCParticleMap, PFOMap, JetMap, MuonMap, ElectronMap, PhotonMap*.
+
+These maps for extra jet collections are optional:
+
+- *ExtraJetMap2, ExtraJetMap3, ExtraJetMap4, ExtraJetMap5, ExtraJetMap6*.
+
+Additional jet collections can be added as long as their name contains the string `"ExtraJet"` and is different from
+all other names. For jet collections the parameter `useDelphes4Vec` defines wether the 4-vector is taken from the delphes
+jet (!=0) or wether it is computed from the jet constituent PFOs (default).

--- a/examples/cpp/delphes2lcio/README.md
+++ b/examples/cpp/delphes2lcio/README.md
@@ -98,6 +98,7 @@ RecoMCTruthLink               LCRelation                     n.a.
 
 ```
 
+See section **Advanced Topics** below how the default collection and branch names can be changed.
 
 This LCIO file can be analyzed like any other LCIO file with the usual tools,e.g.
 
@@ -175,3 +176,31 @@ root [0] .x higgs_recoil_plots.C("../build/E250-TDR_ws.Pe2e2h.Gwhizard-1_95.eR.p
 ```
 root [0] .x higgs_recoil_plots_fast.C("../build/E250-TDR_ws.Pe2e2h.Gwhizard-1_95.eR.pL.I106480.001.mini-DST.slcio")
 ```
+
+
+## Advanced Topics
+
+### Configuration file
+
+The mapping of Delphes branches to LCIO collection by default works for the new ILD delphes card from
+[https://github.com/ILDAnaSoft/ILDDelphes](https://github.com/ILDAnaSoft/ILDDelphes).
+
+If needed, the configuration can be changed, for example if your delphes card produces different output
+branches such as different jet collections.
+
+For an example configuration see [./examples/delphes2lcio.cfg](./examples/delphes2lcio.cfg).
+
+You can copy and edit this file and the add the following lines to your delphes card
+
+
+```
+#################
+# Delphes2LCIO
+#################
+
+set Delphes2LCIO_ConfigFileName "../examples/delphes2lcio.cfg"
+
+```
+
+where the path to the config file has to be either relative from your working directory or preferably
+an absolute path name.

--- a/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
+++ b/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
@@ -51,6 +51,10 @@ branchNameCharged  EFlowTrack
 branchNameNHadron  EFlowNeutralHadron
 branchNamePhoton  EFlowPhoton
 lcioName  PFOs
+massCharged  0.1395701835
+massNHadron  0.9395654133
+pdgCharged  211
+pdgNHadron  2112
 # --------------------------------
 PhotonMap
 branchName  Photon

--- a/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
+++ b/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
@@ -1,0 +1,59 @@
+# ------- DelphesLCIOConfig parameter maps : --------------------- 
+#     default values as used for ILD mini-DSTs
+#
+
+ElectronMap
+branchName  Electron
+lcioName  Electrons
+pdg  -11
+# --------------------------------
+ExtraJetMap2
+branchName  Jet_N2
+lcioName  Durham2Jets
+useDelphes4Vec  0
+# --------------------------------
+ExtraJetMap3
+branchName  Jet_N3
+lcioName  Durham3Jets
+useDelphes4Vec  0
+# --------------------------------
+ExtraJetMap4
+branchName  Jet_N4
+lcioName  Durham4Jets
+useDelphes4Vec  0
+# --------------------------------
+ExtraJetMap5
+branchName  Jet_N5
+lcioName  Durham5Jets
+useDelphes4Vec  0
+# --------------------------------
+ExtraJetMap6
+branchName  Jet_N6
+lcioName  Durham6Jets
+useDelphes4Vec  0
+# --------------------------------
+JetMap
+branchName  Jet
+lcioName  Jets
+useDelphes4Vec  0
+# --------------------------------
+MCParticleMap
+branchName  Particle
+lcioName  MCParticle
+# --------------------------------
+MuonMap
+branchName  Muon
+lcioName  Muons
+pdg  -13
+# --------------------------------
+PFOMap
+branchNameCharged  EFlowTrack
+branchNameNHadron  EFlowNeutralHadron
+branchNamePhoton  EFlowPhoton
+lcioName  PFOs
+# --------------------------------
+PhotonMap
+branchName  Photon
+lcioName  Photons
+pdg  22
+# --------------------------------

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -34,17 +34,19 @@ public:
 
   // ---------------------------------------
   int toInt(const std::string& val){
-    std::stringstream s(val) ;
     int i;
-    s >> i  ;
+    std::stringstream s(val) ;  s >> i  ;
+    if( s.fail() )
+      throw std::runtime_error( std::string("\nDelphesLCIOConfig: cannot convert to int:  ") + val ) ;
     return i;
   }
   // ---------------------------------------
 
   int toFloat(const std::string& val){
-    std::stringstream s(val) ;
     float f;
-    s >> f  ;
+    std::stringstream s(val) ; s >> f  ;
+    if( s.fail() )
+      throw std::runtime_error( std::string("\nDelphesLCIOConfig: cannot convert to float:  ") + val ) ;
     return f;
   }
   // ---------------------------------------
@@ -101,8 +103,9 @@ private:
 
     { "JetMap" ,
       {
-	{ "lcioName"   , "Jets" },
-	{ "branchName" , "Jet" }
+	{ "lcioName"       , "Jets" },
+	{ "branchName"     , "Jet" },
+	{ "useDelphes4Vec" , "0" }
       }   
     },
 

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -32,21 +32,23 @@ public:
   std::string getElectronParameter(const std::string& key) const { return getValue( key , "ElectronMap" ) ; }
 
 
+  // ---------------------------------------
   int toInt(const std::string& val){
     std::stringstream s(val) ;
     int i;
     s >> i  ;
     return i;
   }
+  // ---------------------------------------
+
   int toFloat(const std::string& val){
     std::stringstream s(val) ;
     float f;
     s >> f  ;
     return f;
   }
+  // ---------------------------------------
 
-private:
-  
   std::string getValue(const std::string& key, const std::string& mapName ) const {
 
     auto mit = _maps.find( mapName )  ;
@@ -65,6 +67,7 @@ private:
 
     return it->second ;
   }
+  // ---------------------------------------
 
   std::string getValueSave(const std::string& key, const ConfMap& m) const {
 
@@ -75,25 +78,8 @@ private:
 
   //===============================================================
 
-  ConfMap _mcpMap = {
-    { "lcioName"   , "MCParticle" },
-    { "branchName" , "Particle" }
-  }; 
+private:
 
-
-  ConfMap _pfoMap = {
-    { "lcioName"          , "PFOs" },
-    { "branchNameCharged" , "EFlowTrack" },
-    { "branchNameNHad"    , "EFlowNeutralHadron" },
-    { "branchNamePhoton"  , "EFlowPhoton" },
-  }; 
-
-  ConfMap _jetMap ;
-  ConfMap _muonMap ;
-  ConfMap _photonMap ;
-  ConfMap _electronMap ;
-
-  //===============================================================
 
   std::map< std::string, ConfMap > _maps =
   {

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -4,7 +4,7 @@
 
 #include <map>
 #include <string>
-#include <sstream>
+#include <vector>
 
 
 typedef std::map< std::string, std::string > ConfMap ;
@@ -24,60 +24,45 @@ class DelphesLCIOConfig{
 
 public:
   
-  std::string getMCPParameter(const std::string& key)      const { return getValue( key , "MCParticleMap" ) ; }
-  std::string getPFOParameter(const std::string& key)      const { return getValue( key , "PFOMap" ) ; }
-  std::string getJetParameter(const std::string& key)      const { return getValue( key , "JetMap" ) ; }
-  std::string getMuonParameter(const std::string& key)     const { return getValue( key , "MuonMap" ) ; }
-  std::string getPhotonParameter(const std::string& key)   const { return getValue( key , "PhotonMap" ) ; }
-  std::string getElectronParameter(const std::string& key) const { return getValue( key , "ElectronMap" ) ; }
+
+  /// return parameter for default MCParticle collection
+  std::string getMCPParameter(const std::string& key)      const { return getMapParameter( key , "MCParticleMap" ) ; }
+
+  /// return parameter for default PFO collection
+  std::string getPFOParameter(const std::string& key)      const { return getMapParameter( key , "PFOMap" ) ; }
+
+  /// return parameter for default Jet collection
+  std::string getJetParameter(const std::string& key)      const { return getMapParameter( key , "JetMap" ) ; }
+
+  /// return parameter for default Muon collection
+  std::string getMuonParameter(const std::string& key)     const { return getMapParameter( key , "MuonMap" ) ; }
+
+  /// return parameter for default Photon collection
+  std::string getPhotonParameter(const std::string& key)   const { return getMapParameter( key , "PhotonMap" ) ; }
+
+  /// return parameter for default Electron collection
+  std::string getElectronParameter(const std::string& key) const { return getMapParameter( key , "ElectronMap" ) ; }
+
+  /// return list of map names for extra jet collection (containing substring 'ExtraJet' )
+  std::vector<std::string> getExtraJetMapNames() const ;
+
+  /// convert string to int
+  int toInt(const std::string& val) const ;
+
+  /// convert string to float
+  int toFloat(const std::string& val) const ;
+
+  /// return the parameter for the given key from the named map - throws if either does not exist
+  std::string getMapParameter(const std::string& key, const std::string& mapName ) const ;
 
 
-  // ---------------------------------------
-  int toInt(const std::string& val){
-    int i;
-    std::stringstream s(val) ;  s >> i  ;
-    if( s.fail() )
-      throw std::runtime_error( std::string("\nDelphesLCIOConfig: cannot convert to int:  ") + val ) ;
-    return i;
-  }
-  // ---------------------------------------
+  /// return a string with the configuration parameter maps
+  std::string toString() const ;
 
-  int toFloat(const std::string& val){
-    float f;
-    std::stringstream s(val) ; s >> f  ;
-    if( s.fail() )
-      throw std::runtime_error( std::string("\nDelphesLCIOConfig: cannot convert to float:  ") + val ) ;
-    return f;
-  }
-  // ---------------------------------------
+  /// read a new configuration from the given file
+  void readConfigFile(const std::string& fileName ) ;
 
-  std::string getValue(const std::string& key, const std::string& mapName ) const {
-
-    auto mit = _maps.find( mapName )  ;
-
-    if( mit == _maps.end() )
-      throw std::runtime_error( std::string("\nDelphesLCIOConfig: no configuration map found with name: ")
-				+ mapName ) ;
-
-    const ConfMap& m = mit->second ; 
-    
-    auto it = m.find( key ) ;
-
-    if( it == m.end() )
-      throw std::runtime_error( std::string("\nDelphesLCIOConfig: key : ") + key
-				+  std::string(" not found in map: ") + mapName ) ;
-
-    return it->second ;
-  }
-  // ---------------------------------------
-
-  std::string getValueSave(const std::string& key, const ConfMap& m) const {
-
-    auto it = m.find( key ) ;
-
-    return ( it != m.end() ? it->second : std::string("")  ) ;
-  }
-
+  std::string getMapParameterSave(const std::string& key, const ConfMap& m) const ;
   //===============================================================
 
 private:
@@ -85,6 +70,8 @@ private:
 
   std::map< std::string, ConfMap > _maps =
   {
+    // ---- default collections for mini-DST
+
     { "MCParticleMap" ,
       {
 	{ "lcioName"   , "MCParticle" },
@@ -131,7 +118,17 @@ private:
 	{ "branchName" , "Photon" },
 	{ "pdg" , "22" }
       }   
-    }
+    },
+
+    // ----- additional jet collections ----------------
+
+    { "ExtraJetMap2" , { { "lcioName", "Durham2Jets" }, { "branchName", "Jet_N2" }, { "useDelphes4Vec" , "0" } } },
+    { "ExtraJetMap3" , { { "lcioName", "Durham3Jets" }, { "branchName", "Jet_N3" }, { "useDelphes4Vec" , "0" } } },
+    { "ExtraJetMap4" , { { "lcioName", "Durham4Jets" }, { "branchName", "Jet_N4" }, { "useDelphes4Vec" , "0" } } },
+    { "ExtraJetMap5" , { { "lcioName", "Durham5Jets" }, { "branchName", "Jet_N5" }, { "useDelphes4Vec" , "0" } } },
+    { "ExtraJetMap6" , { { "lcioName", "Durham6Jets" }, { "branchName", "Jet_N6" }, { "useDelphes4Vec" , "0" } } }
+
+
   } ;
 
 };

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -83,7 +83,11 @@ private:
       {
 	{ "lcioName"          , "PFOs" },
 	{ "branchNameCharged" , "EFlowTrack" },
+	{ "pdgCharged"        , "211" },
+	{ "massCharged"       , "0.1395701835" },
 	{ "branchNameNHadron" , "EFlowNeutralHadron" },
+	{ "pdgNHadron"        , "2112" },
+	{ "massNHadron"       , "0.9395654133" },
 	{ "branchNamePhoton"  , "EFlowPhoton" }
       }
     },

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -1,0 +1,150 @@
+#ifndef DelphesLCIOConfig_h
+#define DelphesLCIOConfig_h
+
+
+#include <map>
+#include <string>
+#include <sstream>
+
+
+typedef std::map< std::string, std::string > ConfMap ;
+
+
+
+/** \class DelphesLCIOConfig
+ *
+ *  Configuration helper class for Delphes to LCIO conversion
+ *
+ *  \author F.Gaede, DESY
+ *  \date June 2020
+ *
+ */
+
+class DelphesLCIOConfig{
+
+public:
+  
+  std::string getMCPParameter(const std::string& key)      const { return getValue( key , "MCParticleMap" ) ; }
+  std::string getPFOParameter(const std::string& key)      const { return getValue( key , "PFOMap" ) ; }
+  std::string getJetParameter(const std::string& key)      const { return getValue( key , "JetMap" ) ; }
+  std::string getMuonParameter(const std::string& key)     const { return getValue( key , "MuonMap" ) ; }
+  std::string getPhotonParameter(const std::string& key)   const { return getValue( key , "PhotonMap" ) ; }
+  std::string getElectronParameter(const std::string& key) const { return getValue( key , "ElectronMap" ) ; }
+
+
+  int toInt(const std::string& val){
+    std::stringstream s(val) ;
+    int i;
+    s >> i  ;
+    return i;
+  }
+  int toFloat(const std::string& val){
+    std::stringstream s(val) ;
+    float f;
+    s >> f  ;
+    return f;
+  }
+
+private:
+  
+  std::string getValue(const std::string& key, const std::string& mapName ) const {
+
+    auto mit = _maps.find( mapName )  ;
+
+    if( mit == _maps.end() )
+      throw std::runtime_error( std::string("\nDelphesLCIOConfig: no configuration map found with name: ")
+				+ mapName ) ;
+
+    const ConfMap& m = mit->second ; 
+    
+    auto it = m.find( key ) ;
+
+    if( it == m.end() )
+      throw std::runtime_error( std::string("\nDelphesLCIOConfig: key : ") + key
+				+  std::string(" not found in map: ") + mapName ) ;
+
+    return it->second ;
+  }
+
+  std::string getValueSave(const std::string& key, const ConfMap& m) const {
+
+    auto it = m.find( key ) ;
+
+    return ( it != m.end() ? it->second : std::string("")  ) ;
+  }
+
+  //===============================================================
+
+  ConfMap _mcpMap = {
+    { "lcioName"   , "MCParticle" },
+    { "branchName" , "Particle" }
+  }; 
+
+
+  ConfMap _pfoMap = {
+    { "lcioName"          , "PFOs" },
+    { "branchNameCharged" , "EFlowTrack" },
+    { "branchNameNHad"    , "EFlowNeutralHadron" },
+    { "branchNamePhoton"  , "EFlowPhoton" },
+  }; 
+
+  ConfMap _jetMap ;
+  ConfMap _muonMap ;
+  ConfMap _photonMap ;
+  ConfMap _electronMap ;
+
+  //===============================================================
+
+  std::map< std::string, ConfMap > _maps =
+  {
+    { "MCParticleMap" ,
+      {
+	{ "lcioName"   , "MCParticle" },
+	{ "branchName" , "Particle" }
+      }   
+    },
+
+    { "PFOMap" ,
+      {
+	{ "lcioName"          , "PFOs" },
+	{ "branchNameCharged" , "EFlowTrack" },
+	{ "branchNameNHadron" , "EFlowNeutralHadron" },
+	{ "branchNamePhoton"  , "EFlowPhoton" }
+      }
+    },
+
+    { "JetMap" ,
+      {
+	{ "lcioName"   , "Jets" },
+	{ "branchName" , "Jet" }
+      }   
+    },
+
+    { "MuonMap" ,
+      {
+	{ "lcioName"   , "Muons" },
+	{ "branchName" , "Muon" },
+	{ "pdg" , "-13" }
+      }   
+    },
+
+    { "ElectronMap" ,
+      {
+	{ "lcioName"   , "Electrons" },
+	{ "branchName" , "Electron" },
+	{ "pdg" , "-11" }
+      }   
+    },
+
+    { "PhotonMap" ,
+      {
+	{ "lcioName"   , "Photons" },
+	{ "branchName" , "Photon" },
+	{ "pdg" , "22" }
+      }   
+    }
+  } ;
+
+};
+
+#endif

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
@@ -26,6 +26,9 @@ namespace UTIL{
   class LCRelationNavigator;
 }
 
+class DelphesLCIOConfig ;
+
+
 /** \class DelphesLCIOConverter
  *
  *  Class handling output of ROOT tree in LCIO
@@ -58,11 +61,13 @@ public:
 
 
 private:
-  IO::LCWriter *fWriter=nullptr;
-  IMPL::LCCollectionVec *fEvtSumCol=nullptr;
+  IO::LCWriter *_writer=nullptr;
+  IMPL::LCCollectionVec *_evtSumCol=nullptr;
 
-  std::map< unsigned, EVENT::MCParticle*> mcpd2lmap ;
-  std::map< unsigned, EVENT::ReconstructedParticle*> recd2lmap ;
+  std::map< unsigned, EVENT::MCParticle*> _mcpd2lmap ;
+  std::map< unsigned, EVENT::ReconstructedParticle*> _recd2lmap ;
+
+  DelphesLCIOConfig* _cfg ;
 
 };
 

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
@@ -42,29 +42,33 @@ public:
 
   ///c'tor intializes an LCWriter if valid non-empty file name given
   DelphesLCIOConverter(const char* fileName = "" );
+
+  /// d'tor
   ~DelphesLCIOConverter();
 
+  /// read the configuration file with parameter maps containing collection and branch names etc.
+  void readConfigFile( const char* fileName ) ;
 
   /// convert the Delphes tree to LCIO collections and add them to the event
-  void convertTree2LCIO( TTree *tree , IMPL::LCEventImpl* evt) ;
+  void convertTree2LCIO( TTree *tree , IMPL::LCEventImpl* evt ) ;
 
   /// create a new LCIO event and write it to the writer (if valid)
-  void writeEvent(TTree* tree) ;
+  void writeEvent( TTree* tree ) ;
 
 
   /** Helper function to convert convert a (isolated) particle reference collection. Assumes that the referenced
    *  ReconstructedParticles (PFOs) have been created and are in the relation nafigator. If pdg is given the PFO
    *  type is set to pdg*charge.
    */
-  bool convertPFORefCollection(TClonesArray* tca, EVENT::LCCollection* col, UTIL::LCRelationNavigator& mcrecNav,
-			       std::function<unsigned(TObject*)> uid, int pdg=-99) ;
+  bool convertPFORefCollection( TClonesArray* tca, EVENT::LCCollection* col, UTIL::LCRelationNavigator& mcrecNav,
+			       std::function<unsigned(TObject*)> uid, int pdg=-99 ) ;
 
 
   /** Helper function to convert convert a jet collection. Assumes that the referenced
    *  ReconstructedParticles (PFOs) have been created beforehand. If useDelphes4Vec != 0  the four vector from
    *  the Delphes jet is used otherwise it is computed from the constituent PFOs.
    */
-  bool convertJetCollection(TClonesArray* tca, EVENT::LCCollection* col, int useDelphes4Vec=0) ;
+  bool convertJetCollection( TClonesArray* tca, EVENT::LCCollection* col, int useDelphes4Vec=0 ) ;
 
 private:
   IO::LCWriter *_writer=nullptr;

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
@@ -60,6 +60,12 @@ public:
 			       std::function<unsigned(TObject*)> uid, int pdg=-99) ;
 
 
+  /** Helper function to convert convert a jet collection. Assumes that the referenced
+   *  ReconstructedParticles (PFOs) have been created beforehand. If useDelphes4Vec != 0  the four vector from
+   *  the Delphes jet is used otherwise it is computed from the constituent PFOs.
+   */
+  bool convertJetCollection(TClonesArray* tca, EVENT::LCCollection* col, int useDelphes4Vec=0) ;
+
 private:
   IO::LCWriter *_writer=nullptr;
   IMPL::LCCollectionVec *_evtSumCol=nullptr;

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
@@ -2,15 +2,29 @@
 #define DelphesLCIOConverter_h
 
 
+#include <string>
+#include <map>
+#include <functional>
+
 class TTree;
+class TClonesArray;
+class TObject;
 
 namespace IO{ class LCWriter ; }
-namespace EVENT{ class LCEvent ; }
+namespace EVENT{
+  class LCEvent ;
+  class MCParticle;
+  class ReconstructedParticle;
+  class LCCollection;
+}
 namespace IMPL{
   class LCEventImpl ;
   class LCCollectionVec;
 }
 
+namespace UTIL{
+  class LCRelationNavigator;
+}
 
 /** \class DelphesLCIOConverter
  *
@@ -35,10 +49,21 @@ public:
   void writeEvent(TTree* tree) ;
 
 
-  
+  /** Helper function to convert convert a (isolated) particle reference collection. Assumes that the referenced
+   *  ReconstructedParticles (PFOs) have been created and are in the relation nafigator. If pdg is given the PFO
+   *  type is set to pdg*charge.
+   */
+  bool convertPFORefCollection(TClonesArray* tca, EVENT::LCCollection* col, UTIL::LCRelationNavigator& mcrecNav,
+			       std::function<unsigned(TObject*)> uid, int pdg=-99) ;
+
+
 private:
   IO::LCWriter *fWriter=nullptr;
   IMPL::LCCollectionVec *fEvtSumCol=nullptr;
+
+  std::map< unsigned, EVENT::MCParticle*> mcpd2lmap ;
+  std::map< unsigned, EVENT::ReconstructedParticle*> recd2lmap ;
+
 };
 
 #endif /* DelphesLCIOConverter */

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
@@ -1,0 +1,139 @@
+
+#include "DelphesLCIOConfig.h"
+
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+/// return list of map names for extra jet collection (containing substring 'ExtraJet' )
+std::vector<std::string> DelphesLCIOConfig::getExtraJetMapNames() const {
+
+  std::vector<std::string> ejmapNames ;
+
+  for( auto& it : _maps ){
+      
+    if( ( it.first.find( "ExtraJet" ) != std::string::npos) )
+      ejmapNames.push_back( it.first ) ;
+  }
+  return ejmapNames ;
+}
+
+// ---------------------------------------
+/// convert string to int
+int DelphesLCIOConfig::toInt(const std::string& val) const {
+  int i;
+  std::stringstream s(val) ;  s >> i  ;
+  if( s.fail() )
+    throw std::runtime_error( std::string("\nDelphesLCIOConfig: cannot convert to int:  ") + val ) ;
+  return i;
+}
+
+/// convert string to float
+int DelphesLCIOConfig::toFloat(const std::string& val) const {
+  float f;
+  std::stringstream s(val) ; s >> f  ;
+  if( s.fail() )
+    throw std::runtime_error( std::string("\nDelphesLCIOConfig: cannot convert to float:  ") + val ) ;
+  return f;
+}
+// ---------------------------------------
+
+std::string DelphesLCIOConfig::getMapParameter(const std::string& key, const std::string& mapName ) const {
+
+  auto mit = _maps.find( mapName )  ;
+
+  if( mit == _maps.end() )
+    throw std::runtime_error( std::string("\nDelphesLCIOConfig: no configuration map found with name: ")
+			      + mapName ) ;
+
+  const ConfMap& m = mit->second ; 
+    
+  auto it = m.find( key ) ;
+
+  if( it == m.end() )
+    throw std::runtime_error( std::string("\nDelphesLCIOConfig: key : ") + key
+			      +  std::string(" not found in map: ") + mapName ) ;
+
+  return it->second ;
+}
+// ---------------------------------------
+
+std::string DelphesLCIOConfig::getMapParameterSave(const std::string& key, const ConfMap& m) const {
+
+  auto it = m.find( key ) ;
+
+  return ( it != m.end() ? it->second : std::string("")  ) ;
+}
+
+// ---------------------------------------
+
+std::string DelphesLCIOConfig::toString() const {
+
+  std::stringstream s ;
+  s << "\n# ------- DelphesLCIOConfig parameter maps : --------------------- \n\n" ;
+  for( const auto& it : _maps ){
+    s << it.first << "\n" ;
+    const auto& m = it.second ;
+    for( auto& kv : m ){
+      s << kv.first << "  " << kv.second  << "\n" ;
+    }
+    s << "# --------------------------------" << "\n" ;
+  }
+  return s.str() ;
+}
+// ---------------------------------------
+
+void DelphesLCIOConfig::readConfigFile(const std::string& fileName ) {
+
+  std::cout << " DelphesLCIOConfig read new configuration from file: " << fileName << std::endl ;
+
+  std::ifstream in(fileName);
+
+  if(!in){
+    std::cerr << "DelphesLCIOConfig: cannot open the File : " << fileName <<std::endl;
+    exit(1) ;
+  }
+
+  std::string line ;
+  std::string mapName ;
+
+  ConfMap cmap ;
+  
+  while (std::getline(in, line)) {
+
+    // Line contains string of length > 0 then save it in vector
+    if( line.empty() || line[0] == '#' )
+      continue ;
+
+    // split on white space
+    std::vector<std::string> strings ;
+    std::istringstream iss(line);
+    for(std::string s; iss >> s; )
+      strings.push_back(s);
+
+    if( strings.size() == 1 ){ // new config map
+
+      if( !cmap.empty() && !mapName.empty() )
+	_maps[ mapName ] = cmap ;
+
+      cmap.clear() ;
+      mapName = strings[0] ;
+
+    } else if(strings.size() == 2 ){ // new map entry 
+
+      cmap[ strings[0] ] = strings[1] ;
+
+    } else {
+      std::cout << " wrong number of strings on line " << std::endl ;
+      for(auto s : strings )
+	std::cout << "   " << s << " | " ;
+      std::cout << "\n" ;
+    }
+  }
+
+  if( !cmap.empty() && !mapName.empty() )
+    _maps[ mapName ] = cmap ;
+  
+
+  in.close();
+}

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
@@ -81,6 +81,8 @@ std::string DelphesLCIOConfig::toString() const {
   }
   return s.str() ;
 }
+
+
 // ---------------------------------------
 
 void DelphesLCIOConfig::readConfigFile(const std::string& fileName ) {
@@ -94,6 +96,12 @@ void DelphesLCIOConfig::readConfigFile(const std::string& fileName ) {
     exit(1) ;
   }
 
+
+  //std::cout << " --- old config : " << toString() << std::endl ;
+
+  _maps.clear() ;
+
+
   std::string line ;
   std::string mapName ;
 
@@ -101,11 +109,11 @@ void DelphesLCIOConfig::readConfigFile(const std::string& fileName ) {
   
   while (std::getline(in, line)) {
 
-    // Line contains string of length > 0 then save it in vector
+    // ignore empty lines and commented lines
     if( line.empty() || line[0] == '#' )
       continue ;
 
-    // split on white space
+    // split line on white space
     std::vector<std::string> strings ;
     std::istringstream iss(line);
     for(std::string s; iss >> s; )
@@ -134,6 +142,8 @@ void DelphesLCIOConfig::readConfigFile(const std::string& fileName ) {
   if( !cmap.empty() && !mapName.empty() )
     _maps[ mapName ] = cmap ;
   
+  //std::cout << " --- new config : " << toString() << std::endl ;
 
   in.close();
 }
+// ---------------------------------------

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
@@ -93,6 +93,12 @@ DelphesLCIOConverter::~DelphesLCIOConverter(){
     delete _writer ;
   }
 }
+//-----------------------------------------------------------------
+
+void DelphesLCIOConverter::readConfigFile( const char* fileName ){
+
+  _cfg->readConfigFile( fileName ) ;
+}
 
 //-----------------------------------------------------------------
 

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
@@ -243,7 +243,7 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
   //=====================================================================
 
 
-  TBranch *trB = tree->GetBranch("EFlowTrack");
+  TBranch *trB = tree->GetBranch( _cfg->getPFOParameter("branchNameCharged").c_str()  );
   if( trB != nullptr ){
 
     TClonesArray* col = *(TClonesArray**) trB->GetAddress()  ;
@@ -310,7 +310,7 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
   }
   //----------------------------------------------------------------------------
 
-  TBranch *nhB = tree->GetBranch("EFlowNeutralHadron");
+  TBranch *nhB = tree->GetBranch( _cfg->getPFOParameter("branchNameNHadron").c_str() );
   if( nhB != nullptr ){
 
     TClonesArray* col = *(TClonesArray**) nhB->GetAddress()  ;
@@ -374,7 +374,7 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
   }
   //----------------------------------------------------------------------------------
 
-  TBranch *efphB = tree->GetBranch("EFlowPhoton");
+  TBranch *efphB = tree->GetBranch(  _cfg->getPFOParameter("branchNamePhoton").c_str() );
   if( efphB != nullptr ){
 
     TClonesArray* col = *(TClonesArray**) efphB->GetAddress()  ;

--- a/examples/cpp/delphes2lcio/src/DelphesSTDHEP2LCIO.cpp
+++ b/examples/cpp/delphes2lcio/src/DelphesSTDHEP2LCIO.cpp
@@ -122,6 +122,10 @@ int main(int argc, char *argv[])
     maxEvents = confReader->GetInt("::MaxEvents", 0);
     skipEvents = confReader->GetInt("::SkipEvents", 0);
 
+    std::string d2lCfgFile = confReader->GetString("::Delphes2LCIO_ConfigFileName", "");
+    if( ! d2lCfgFile.empty() )
+      lcioConverter.readConfigFile( d2lCfgFile.c_str() ) ;
+
     if(maxEvents < 0)
     {
       throw runtime_error("MaxEvents must be zero or positive");


### PR DESCRIPTION

BEGINRELEASENOTES
- improve the delphes2lcio tool
     - add configuration options for LCIO collection names and delphes branches to be used
     - the default configuration works for the ILD delphes card [https://github.com/ILDAnaSoft/ILDDelphes](https://github.com/ILDAnaSoft/ILDDelphes)
     - it can be overwritten with a simple configuration file see ./examples/delphes2lcio.cfg and *Advanced Topics* in the READM.md
     - additional jet collections can be added to the event if available in the delphes output
             - current default are *Durham2Jets-Durham6Jets*

ENDRELEASENOTES