### PR TITLE
fix bug in build dependency

### DIFF
--- a/sio/CMakeLists.txt
+++ b/sio/CMakeLists.txt
@@ -37,6 +37,6 @@ INSTALL_SHARED_LIBRARY( sio DESTINATION lib )
 
 # mimic the SIOConfig.cmake variables for the LCIO project
 SET( SIO_VERSION                  "${SIO_VERSION}"                       CACHE STRING "The SIO version" )
-SET( SIO_LIBRARIES                "$<TARGET_FILE:sio>"                   CACHE STRING "The SIO library" )
+SET( SIO_LIBRARIES                "sio"                                  CACHE STRING "The SIO library" )
 SET( SIO_INCLUDE_DIRS             "${CMAKE_CURRENT_SOURCE_DIR}/include"  CACHE STRING "The path to SIO include directories" )
 SET( CHECK_PACKAGE_SIO_LIBRARY    "sio"                                  CACHE STRING "The name of the builtin SIO library to check when searching for LCIO package" )


### PR DESCRIPTION
BEGINRELEASENOTES
- fix bug in build dependency, affecting only build on large number of cores

ENDRELEASENOTES

If you build on many cores, you would start building things that need `libsio` before this was available and you get into this situation

```
[ 42%] Building CXX object lcio/CMakeFiles/lcio.dir/src/SIO/LCIORandomAccessMgr.cc.o
[ 42%] Building CXX object lcio/CMakeFiles/lcio.dir/src/SIO/RunEventMap.cc.o
make[2]: *** No rule to make target 'lib/libsio.so.0.0.2', needed by 'lib/liblcio.so.2.14.2'.  Stop.
make[2]: *** Waiting for unfinished jobs....
[ 43%] Building CXX object lcio/CMakeFiles/lcio.dir/src/MT/LCWriter.cc.o
[ 43%] Building CXX object lcio/CMakeFiles/lcio.dir/src/MT/LCReader.cc.o
[ 44%] Linking CXX shared library ../lib/libsio.so
[ 44%] Built target sio
``` 

bug fix courtesy of @andresailer 
