### PR TITLE
fix memory leak in SIOReader

### DIFF
--- a/src/cpp/include/SIO/SIOReader.h
+++ b/src/cpp/include/SIO/SIOReader.h
@@ -209,6 +209,11 @@ namespace SIO {
     std::set<IO::LCRunListener*>         _runListeners {} ;
     /// The event listeners
     std::set<IO::LCEventListener*>       _evtListeners {} ;
+    /// pointer to current Event
+    EVENT::LCEvent* _currentEvent = nullptr ;
+    /// pointer to current RunHeader
+    EVENT::LCRunHeader* _currentRun = nullptr ;
+
   }; // class
 } // namespace
 

--- a/src/cpp/src/SIO/SIOReader.cc
+++ b/src/cpp/src/SIO/SIOReader.cc
@@ -81,7 +81,13 @@ namespace SIO {
   //----------------------------------------------------------------------------
 
   EVENT::LCRunHeader* SIOReader::readNextRunHeader(int accessMode) {
-    return _reader.readNextRunHeader( accessMode ).release() ;
+
+    if( _currentRun != nullptr ){
+      delete _currentRun ;
+    }
+    _currentRun = _reader.readNextRunHeader( accessMode ).release() ;
+
+    return _currentRun ;
   }
   
   //----------------------------------------------------------------------------
@@ -93,7 +99,13 @@ namespace SIO {
   //----------------------------------------------------------------------------
 
   EVENT::LCEvent* SIOReader::readNextEvent(int accessMode)  {
-    return _reader.readNextEvent( accessMode ).release() ;
+
+    if( _currentEvent != nullptr ){
+      delete _currentEvent ;
+    }
+    _currentEvent = _reader.readNextEvent( accessMode ).release() ;
+
+    return _currentEvent ;
   }
 
   //----------------------------------------------------------------------------
@@ -111,7 +123,13 @@ namespace SIO {
   //----------------------------------------------------------------------------
 
   EVENT::LCRunHeader * SIOReader::readRunHeader(int runNumber, int accessMode) {
-    return _reader.readRunHeader( runNumber, accessMode ).release() ;
+
+    if( _currentRun != nullptr ){
+      delete _currentRun ;
+    }
+    _currentRun = _reader.readRunHeader( runNumber, accessMode ).release() ;
+
+    return _currentRun ;
   }
 
   //----------------------------------------------------------------------------
@@ -123,7 +141,13 @@ namespace SIO {
   //----------------------------------------------------------------------------
 
   EVENT::LCEvent * SIOReader::readEvent(int runNumber, int evtNumber, int accessMode) {
-    return _reader.readEvent( runNumber, evtNumber, accessMode ).release() ;
+
+    if( _currentEvent != nullptr ){
+      delete _currentEvent ;
+    }
+    _currentEvent = _reader.readEvent( runNumber, evtNumber, accessMode ).release() ;
+
+    return _currentEvent ;
   }
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
BEGINRELEASENOTES
- fix memory leak in SIOReader
     - delete previous Event and RunHeader before reading a new one
     - this restores the old expected behavior of the `IO::LCReader`
     - for parallel event reading one needs to use the `MT::LCReader` directly and
        handle the memory accordingly (e.g. via use of std::unique_ptr)
             - see [$LCIO/src/cpp/src/EXAMPLE/lcio_parallel_processing.cc](../src/cpp/src/EXAMPLE/lcio_parallel_processing.cc)
- fixes #97 and #98 

ENDRELEASENOTES