### PR TITLE
improve the delphes2lcio tool

### DIFF
--- a/examples/cpp/delphes2lcio/README.md
+++ b/examples/cpp/delphes2lcio/README.md
@@ -81,13 +81,13 @@ This creates an LCIO files with the following default collections:
 ---------------------------------------------------------------------------
 COLLECTION NAME               COLLECTION TYPE            DELPHES BRANCH
 ===========================================================================
-Electrons                     ReconstructedParticle        Electron
+IsolatedElectrons             ReconstructedParticle        Electron
 Jets                          ReconstructedParticle        Jet
-MCParticle                    MCParticle                   Particle
+MCParticles                   MCParticle                   Particle
 MCTruthRecoLink               LCRelation                     n.a.
-Muons                         ReconstructedParticle        Muon
+IsolatedMuons                 ReconstructedParticle        Muon
 PFOs                          ReconstructedParticle        EFlowTrack,EFlowPhoton,EFlowNeutralHadron
-Photons                       ReconstructedParticle        Photon
+IsolatedPhotons               ReconstructedParticle        Photon
 RecoMCTruthLink               LCRelation                     n.a.
 ---------------------------------------------------------------------------
 

--- a/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
+++ b/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
@@ -4,7 +4,7 @@
 
 ElectronMap
 branchName  Electron
-lcioName  Electrons
+lcioName  IsolatedElectrons
 pdg  -11
 # --------------------------------
 ExtraJetMap2
@@ -44,11 +44,11 @@ useDelphes4Vec  0
 # --------------------------------
 MCParticleMap
 branchName  Particle
-lcioName  MCParticle
+lcioName  MCParticles
 # --------------------------------
 MuonMap
 branchName  Muon
-lcioName  Muons
+lcioName  IsolatedMuons
 pdg  -13
 # --------------------------------
 PFOMap
@@ -63,6 +63,6 @@ pdgNHadron  2112
 # --------------------------------
 PhotonMap
 branchName  Photon
-lcioName  Photons
+lcioName  IsolatedPhotons
 pdg  22
 # --------------------------------

--- a/examples/cpp/delphes2lcio/examples/higgs_recoil_plots.C
+++ b/examples/cpp/delphes2lcio/examples/higgs_recoil_plots.C
@@ -63,8 +63,8 @@ void higgs_recoil_plots(const char* FILEN) {
 //---------------------------------
  
  IO::LCReader* lcReader = IOIMPL::LCFactory::getInstance()->createLCReader() ;
- lcReader->setReadCollectionNames( { "PFOs","Jets","Muons" } );
- //lcReader->setReadCollectionNames( {"MCParticle", "PFOs", "RecoMCTruthLink" ,"MCTruthRecoLink","Jets","Muons" } ) ;
+ lcReader->setReadCollectionNames( { "PFOs","Jets","IsolatedMuons" } );
+ //lcReader->setReadCollectionNames( {"MCParticle", "PFOs", "RecoMCTruthLink" ,"MCTruthRecoLink","Jets","IsolatedMuons" } ) ;
  lcReader->open( FILEN ) ;
   
 
@@ -75,7 +75,7 @@ void higgs_recoil_plots(const char* FILEN) {
    
    
    LCIterator<ReconstructedParticle> jets( evt, "Jets" ) ;
-   LCIterator<ReconstructedParticle> muons( evt, "Muons" ) ;
+   LCIterator<ReconstructedParticle> muons( evt, "IsolatedMuons" ) ;
 
    if( jets.size() != 2)
      continue;

--- a/examples/cpp/delphes2lcio/examples/higgs_recoil_plots_fast.C
+++ b/examples/cpp/delphes2lcio/examples/higgs_recoil_plots_fast.C
@@ -68,8 +68,10 @@ void higgs_recoil_plots_fast(const char* FILEN) {
 //---------------------------------
  
  IO::LCReader* lcReader = IOIMPL::LCFactory::getInstance()->createLCReader() ;
- lcReader->setReadCollectionNames( { "PFOs","Jets","Muons" , "EventSummaries"} );
- //lcReader->setReadCollectionNames( {"MCParticle", "PFOs", "RecoMCTruthLink" ,"MCTruthRecoLink","Jets","Muons" } ) ;
+
+ // read only these collections from the file (faster):
+ lcReader->setReadCollectionNames( { "PFOs","Jets","IsolatedMuons" , "EventSummaries"} );
+
  lcReader->open( FILEN ) ;
   
 
@@ -119,7 +121,7 @@ void higgs_recoil_plots_fast(const char* FILEN) {
      //----------  the actual event processing
    
      LCIterator<ReconstructedParticle> jets( evt, "Jets" ) ;
-     LCIterator<ReconstructedParticle> muons( evt, "Muons" ) ;
+     LCIterator<ReconstructedParticle> muons( evt, "IsolatedMuons" ) ;
      
      if( jets.size() != 2)
        continue;

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -74,7 +74,7 @@ private:
 
     { "MCParticleMap" ,
       {
-	{ "lcioName"   , "MCParticle" },
+	{ "lcioName"   , "MCParticles" },
 	{ "branchName" , "Particle" }
       }   
     },
@@ -102,7 +102,7 @@ private:
 
     { "MuonMap" ,
       {
-	{ "lcioName"   , "Muons" },
+	{ "lcioName"   , "IsolatedMuons" },
 	{ "branchName" , "Muon" },
 	{ "pdg" , "-13" }
       }   
@@ -110,7 +110,7 @@ private:
 
     { "ElectronMap" ,
       {
-	{ "lcioName"   , "Electrons" },
+	{ "lcioName"   , "IsolatedElectrons" },
 	{ "branchName" , "Electron" },
 	{ "pdg" , "-11" }
       }   
@@ -118,7 +118,7 @@ private:
 
     { "PhotonMap" ,
       {
-	{ "lcioName"   , "Photons" },
+	{ "lcioName"   , "IsolatedPhotons" },
 	{ "branchName" , "Photon" },
 	{ "pdg" , "22" }
       }   

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
@@ -198,6 +198,10 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
     evt->setEventNumber( e->Number ) ;
     evt->setWeight( e->Weight ) ;
     evt->setTimeStamp( e->ReadTime ) ;
+
+    evt->parameters().setValue("crossSection",  e->CrossSection ) ;
+    evt->parameters().setValue("ProcessID",     e->ProcessID  ) ;
+
   }
 
   //=====================================================================

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
@@ -31,6 +31,7 @@
 #include "UTIL/LCIterator.h"
 #include "UTIL/Operators.h"
 #include "UTIL/EventSummary.h"
+#include "UTIL/ProcessFlag.h"
 
 #include <iostream>
 #include <sstream>
@@ -638,7 +639,12 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
     evts->setF( ESF::pymiss, mcppy - pfopy ) ;
     evts->setF( ESF::pzmiss, mcppz - pfopz ) ;
 
-//    std::cout << *evts << std::endl ;
+
+
+    ProcessFlag pFlag = decodeMCTruthProcess( mcps ) ;
+    evts->setI( ESI::mcproc,  pFlag ) ;
+
+//    std::cout << " ---- mc truth process : " << pFlag << std::endl ;
   }
 
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -119,6 +119,7 @@ SET( LCIO_UTIL_SRCS
   ./src/UTIL/CollectionParameterMap.cc
   ./src/UTIL/PIDHandler.cc
   ./src/UTIL/ILDConf.cc
+  ./src/UTIL/ProcessFlag.cc
 )
 
 SET( LCIO_MT_SRCS

--- a/src/cpp/include/UTIL/LCIterator.h
+++ b/src/cpp/include/UTIL/LCIterator.h
@@ -74,7 +74,7 @@ namespace UTIL {
   
     /** Constructor for the given collection.
      */
-    LCIterator<T>( EVENT::LCCollection* col) : _i(0) , _col( col ) {
+    LCIterator<T>( const EVENT::LCCollection* col) : _i(0) , _col( col ) {
     
       _n = (_col ? _col->getNumberOfElements() : 0 ) ;
     
@@ -109,15 +109,15 @@ namespace UTIL {
 
     /** Serves as a handle to the LCCollection itself, to provide access to the collection parameters etc.
      */
-    EVENT::LCCollection* operator->() { return _col ; }
+    const EVENT::LCCollection* operator->() { return _col ; }
 
     /** Return pointer to LCCollection, e.g. for testing whether the collections was in the event.
      */
-    EVENT::LCCollection* operator()() { return _col ; }
+    const EVENT::LCCollection* operator()() { return _col ; }
 
   private:
     int _n{0}, _i ;
-    EVENT::LCCollection* _col ;
+    const EVENT::LCCollection* _col ;
   } ;
 
 } // namespace UTIL

--- a/src/cpp/src/UTIL/ProcessFlag.cc
+++ b/src/cpp/src/UTIL/ProcessFlag.cc
@@ -1,0 +1,71 @@
+
+#include "UTIL/ProcessFlag.h"
+
+#include "EVENT/LCCollection.h"
+#include "EVENT/MCParticle.h" 
+#include "UTIL/LCTOOLS.h"
+//#include "UTIL/LCIterator.h"
+#include "UTIL/Operators.h"
+
+
+namespace UTIL{
+
+  ProcessFlag decodeMCTruthProcess(const EVENT::LCCollection* col, int maxParticles){
+
+//    LCTOOLS::printMCParticles( col ) ;
+
+    ProcessFlag flag ;
+    std::map< int, int> pdgFSCount ;
+    EVENT::MCParticle* higgs = nullptr ;
+    int hDpdg0 =0 , hDpdg1 =0;
+    
+    int np = col->getNumberOfElements() > maxParticles ? maxParticles :  col->getNumberOfElements() ;
+    
+
+    for( int i=0 ; i<np ; ++i){
+
+      EVENT::MCParticle* mcp = static_cast<EVENT::MCParticle*>( col->getElementAt(i) ) ;
+
+      int pdg = std::abs( mcp->getPDG() ) ;
+
+      /// for DBD stdhep files these seem to be the particles of the hard sub-process
+      ///      -> needs generalization to other versions of Whizard ....
+
+      if( mcp->getParents().empty() ){ 
+	pdgFSCount[ pdg ]++ ;
+      }
+
+      if( pdg == 25 && mcp->getDaughters().size()==2 ){ // higgs decay
+
+	hDpdg0 = mcp->getDaughters()[0]->getPDG() ;
+	hDpdg1 = mcp->getDaughters()[1]->getPDG() ;
+	higgs = mcp ;
+      }
+
+    }
+    pdgFSCount[22] -= 2 ; // remove the FSR photons
+
+
+    // fill final state particles into flag:
+
+    for( auto m : pdgFSCount ){
+      if( m.second  > 1 )
+	flag.addFSParticles( m.first ) ;
+    }
+
+    // fill Higgs decay
+    
+    if(higgs != nullptr){
+
+      if( std::abs( hDpdg0 ) == std::abs( hDpdg1 ) ) // particle anti-particle pair
+	flag.addHiggsDecay( std::abs( hDpdg0 ) ) ;
+
+      
+      //FIXME: else deal with other more exotic cases ....
+    }
+
+    
+    return flag ;
+  }
+
+}

--- a/src/cpp/src/UTIL/ProcessFlag.cc
+++ b/src/cpp/src/UTIL/ProcessFlag.cc
@@ -4,13 +4,19 @@
 #include "EVENT/LCCollection.h"
 #include "EVENT/MCParticle.h" 
 #include "UTIL/LCTOOLS.h"
-//#include "UTIL/LCIterator.h"
 #include "UTIL/Operators.h"
 
 
 namespace UTIL{
 
   ProcessFlag decodeMCTruthProcess(const EVENT::LCCollection* col, int maxParticles){
+
+    // this is WIP and needs iteration:
+    //  - make more general for different Whizrd versions
+    //  - deal with BSM and other exotic cases
+    //  - decide on whether individual fermions from W's are used to set the corresponging flag
+    //  - ...
+
 
 //    LCTOOLS::printMCParticles( col ) ;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- improve the `delphes2lcio` tool
        - changes some default collection names
                - Electrons/ Muons/ Photons -> IsolatedElectrons / IsolatedMuons / ...
                - MCParticle -> MCParticles
        - update all examples and Readme.md accordingly
        - add event params: crossSection and ProcessID as available in Delphes
- add method `ProcessFlag decodeMCTruthProcess(const EVENT::LCCollection*) `
        - with first example implementation -> needs iteration
        - call this in `delphes2lcio`
- use `const EVENT::LCCollection*` in `UTIL::LCIterator`
 
ENDRELEASENOTES