### PR TITLE
Improve delphes v1

### DIFF
--- a/examples/cpp/delphes2lcio/README.md
+++ b/examples/cpp/delphes2lcio/README.md
@@ -51,7 +51,7 @@ cd delphes2lcio
 mkdir build
 cd build
 cmake -D LCIO_DIR=$LCIO  ..
-
+make -j 4 install
 ```
 
 ----------
@@ -68,11 +68,15 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LCIO/lib:$DELPHES_DIR/lib
 
 
 ### Running Delphes
-Then you can run Delphes with
+Then you can run Delphes, e.g. with
 
 ```
 DelphesSTDHEP2LCIO $DELPHES_DIR/cards/delphes_card_ILD.tcl output.slcio input.stdhep
 ```
+
+**This is just an example delphes card for ILD that does not work really. Better use the 
+generic ILC Delphes card from [https://github.com/iLCSoft/ILCDelphes](https://github.com/iLCSoft/ILCDelphes)**
+
 
 This creates an LCIO files with the following default collections:
 

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
@@ -640,11 +640,12 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
     evts->setF( ESF::pzmiss, mcppz - pfopz ) ;
 
 
-
+#if LCIO_VERSION_GE( 2 , 15 )
     ProcessFlag pFlag = decodeMCTruthProcess( mcps ) ;
     evts->setI( ESI::mcproc,  pFlag ) ;
-
 //    std::cout << " ---- mc truth process : " << pFlag << std::endl ;
+#endif
+
   }
 
 

--- a/src/cpp/include/UTIL/ProcessFlag.h
+++ b/src/cpp/include/UTIL/ProcessFlag.h
@@ -25,7 +25,8 @@ namespace UTIL{
     bquarks,     ///< bquarks in final state
     higgsbb,     ///< Higss to bbbar decay
     higgscc,     ///< Higss to ccbar decay
-    higgsdd,     ///< Higss to ddbar (or uu,ss) decay
+    higgsdu,     ///< Higss to ddbar or uubar decay
+    higgsss,     ///< Higss to ssbar decay
     higgsgg,     ///< Higss to gg decay
     higgstautau, ///< Higss to tautau decay
     higgsmumu,   ///< Higss to mumu decay
@@ -35,7 +36,8 @@ namespace UTIL{
     higgsgaZ,    ///< Higss to gamma Z decay
     higgsinv,    ///< Higss to invisible decay
     higgsother,  ///< Higss to other decay
-    exotic       ///< exotic process (SUSY etc)
+    exotic,      ///< exotic process (SUSY etc)
+    unknown      ///< unknwon process
   } ;
 
   /// Short name for ProcessorFlagBits
@@ -135,9 +137,9 @@ namespace UTIL{
     std::map< int, PF > _mapH =
     {
       {  5, PF::higgsbb     },
-      {  1, PF::higgsdd     },
-      {  2, PF::higgsdd     },
-      {  3, PF::higgsdd     },
+      {  1, PF::higgsdu     },
+      {  2, PF::higgsdu     },
+      {  3, PF::higgsss     },
       {  4, PF::higgscc     },
       { 15, PF::higgstautau },
       { 13, PF::higgsmumu   },
@@ -146,7 +148,8 @@ namespace UTIL{
       { 22, PF::higgsgaga   },
       { 12, PF::higgsinv    },
       { 14, PF::higgsinv    },
-      { 16, PF::higgsinv    }
+      { 16, PF::higgsinv    },
+      { 1000022, PF::higgsinv }
     } ;
  
   } ;
@@ -167,7 +170,8 @@ namespace UTIL{
     if( flag.has( PF::cquarks   ) ) os << "cquarks|" ;
     if( flag.has( PF::bquarks   ) ) os << "bquarks|" ;
     if( flag.has( PF::higgsbb     ) ) os << "higgsbb|" ;
-    if( flag.has( PF::higgsdd     ) ) os << "higgsdd|" ;
+    if( flag.has( PF::higgsdu     ) ) os << "higgsdu|" ;
+    if( flag.has( PF::higgsss     ) ) os << "higgsss|" ;
     if( flag.has( PF::higgscc     ) ) os << "higgscc|" ;
     if( flag.has( PF::higgstautau ) ) os << "higgstautau|" ;
     if( flag.has( PF::higgsmumu   ) ) os << "higgsmumu|" ;
@@ -178,6 +182,7 @@ namespace UTIL{
     if( flag.has( PF::higgsinv    ) ) os << "higgsinv|" ;
     if( flag.has( PF::higgsother  ) ) os << "higgsother|" ;
     if( flag.has( PF::exotic      ) ) os << "exotic|" ;
+    if( flag.has( PF::unknown     ) ) os << "unknown|" ;
 
     return os;
   }

--- a/src/cpp/include/UTIL/ProcessFlag.h
+++ b/src/cpp/include/UTIL/ProcessFlag.h
@@ -192,6 +192,18 @@ namespace UTIL{
    *  Assumes that the MCParticle collection has been created with a recent version of the Whizard
    *  event generator (since DBD). At most, the first maxParticles are evaluated for identifying 
    *  the hard sub-process.
+   *  icase 1: Whizard 2.8.4: incoming particles of hard subprocess (i.e. after BS, ISR etc) have generatorStatus 3
+   *      => use their daughters as hard final state
+   *  icase 2: DBD files WITHOUT beam particles (e.g. 250 GeV DBD samples) have more than 2 PARENTLESS particles
+   *      => use these as hard final state
+   *  icase 3: DBD files WITH beam particles (e.g. non-Higgs 500 GeV DBD samples) have exactly 2 PARENTLESS particles
+   *      => their daughters are the incoming particles of hard subprocess and the ISR and/or outgoing beam particles
+   *      => select those daughters which have more than one daughter
+   *      => take the daughters of these daughters of the parentless particles as hard final state
+   *  else => only PF::unknown is set
+   * 
+   * \author F.Gaede, J.List, DESY
+   * \date August 2020
    */
   ProcessFlag decodeMCTruthProcess(const EVENT::LCCollection* mcps , int maxParticle=10);
 


### PR DESCRIPTION

BEGINRELEASENOTES
- make delphes2lcio compatible w/ LCIO 2.14 again
         - by not calling `ProcessFlag::decodeMCTruthProcess()`
- add `higgsss` and `unknown` to `ProcessFlag`
- update logic in `ProcessFlag::decodeMCTruthProcess()` (from J.List, DESY)

ENDRELEASENOTES