### PR TITLE
fix ISRs in ProcessFlag::decodeMCTruthProcess

### DIFF
--- a/src/cpp/src/UTIL/ProcessFlag.cc
+++ b/src/cpp/src/UTIL/ProcessFlag.cc
@@ -115,6 +115,11 @@ namespace UTIL{
         higgs = mcp ;
       }
     }
+    // for (icase == 2) we have falsly counted 2 ISR photons:
+    if( icase == 2 )
+      pdgFSCount[ 22 ] -= 2 ;
+
+
     //---------------------------------------------------------------------------------------------------
 
     // fill final state particles into flag:


### PR DESCRIPTION

BEGINRELEASENOTES
- fix `ProcessFlag::decodeMCTruthProcess()`
      - remove ISR photons in final state for DBD 250 GeV files

ENDRELEASENOTES