### PR TITLE
Patch lcio v02 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ it still provides a good overview over the philosophy of LCIO and how to use it.
 ```sh
 git clone https://github.com/iLCSoft/LCIO.git
 cd LCIO
-git checkout v02-14-02    ##  use a specific version
+git checkout v02-15-01    ##  use a specific version
 ```
 
 - if you just want to build a plain version of LCIO:
@@ -63,13 +63,19 @@ cmake ..
 make -j 4 install
 ```
 
-- to get a ROOT dictionary for LCIO that allows to read LCIO files in ROOT macros and provides the Python bindings you need ROOT installed:
+- to get a ROOT dictionary for LCIO that allows to read LCIO files in ROOT macros and provides the Python bindings you need a compatible
+  version of ROOT installed and initialized (*make sure you use a compatible compiler and  C++ standard*), e.g.
 
 ```sh
-. /data/ilcsoft/root/6.18.04/bin/thisroot.sh   # <-- your path to ROOT goes here
-cmake -DBUILD_ROOTDICT=ON ..
+. /cvmfs/ilc.desy.de/sw/x86_64_gcc82_sl6/root/6.18.04/bin/thisroot.sh
+cmake -DBUILD_ROOTDICT=ON -D CMAKE_CXX_STANDARD=17 ..
 make -j 4 install
 cd ..
+```
+
+and then initialize your LCIO installation:
+
+```sh
 . ./setup.sh  ## <--- run this in the source directory
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
+
+#
+# initialize the current LCIO version by sourcing this in the top level directory
+#
+
 export LCIO=`pwd`
 export PATH=$LCIO/bin:$LCIO/tools:$PATH
+export LD_LIBRARY_PATH=$LCIO/lib:$LD_LIBRARY_PATH
 export PYTHONPATH=$LCIO/src/python:$PYTHONPATH
 alias pylcio='python $LCIO/src/python/pylcio.py'

--- a/src/cpp/include/MT/LCWriter.h
+++ b/src/cpp/include/MT/LCWriter.h
@@ -106,7 +106,7 @@ namespace MT {
     /// The compression level
     std::atomic<unsigned int>                   _maxBufferSize {2*1204*1024} ;
     /// The compression level
-    std::atomic<int>                            _compressionLevel {0} ;
+    std::atomic<int>                            _compressionLevel {-1} ;
     /// The random access manager for event/run random access in the file
     std::shared_ptr<SIO::LCIORandomAccessMgr>   _raMgr {nullptr} ;
     /// Synchronization mutex

--- a/src/cpp/src/IOIMPL/LCFactory.cc
+++ b/src/cpp/src/IOIMPL/LCFactory.cc
@@ -37,8 +37,9 @@ namespace IOIMPL{
     
     // the reason for having this class
     // so far we just create SIO objects
-
-    return new SIOWriter ;
+    auto* wrt = new SIOWriter ;
+    wrt->setCompressionLevel( -1 ) ; // default compression level
+    return  wrt ;
   }
   
   LCReader * LCFactory::createLCReader(int lcReaderFlag) {

--- a/src/cpp/src/TESTS/test_splitting.cc
+++ b/src/cpp/src/TESTS/test_splitting.cc
@@ -21,7 +21,7 @@ using namespace std ;
 using namespace lcio ;
 
 //static const int NRUN = 10 ;
-static const int NEVENT = 10 ; // events
+static const int NEVENT = 40 ; // events
 static const int NHITS = 100 ;  // calorimeter hits per event
 static const int SPLIT_SIZE_KB = 9 ;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -311,7 +311,7 @@ ENDIF( CLHEP_FOUND )
 
 # ==== lcio_merge_files tests  ========
 ADD_TEST( t_lcio_merge_files "${EXECUTABLE_OUTPUT_PATH}/lcio_merge_files" merged.slcio splitting.000.slcio splitting.001.slcio splitting.002.slcio splitting.003.slcio splitting.004.slcio )
-SET_TESTS_PROPERTIES( t_lcio_merge_files PROPERTIES PASS_REGULAR_EXPRESSION "merged 10 events from 5 input files." )
+SET_TESTS_PROPERTIES( t_lcio_merge_files PROPERTIES PASS_REGULAR_EXPRESSION "merged 40 events from 5 input files." )
 
 
 # ==== lcio_event_counter tests  ========
@@ -319,13 +319,13 @@ ADD_TEST( t_lcio_event_counter "${EXECUTABLE_OUTPUT_PATH}/lcio_event_counter" tr
 SET_TESTS_PROPERTIES( t_lcio_event_counter PROPERTIES PASS_REGULAR_EXPRESSION "3" )
 
 ADD_TEST( t_lcio_event_counter_splitting "${EXECUTABLE_OUTPUT_PATH}/lcio_event_counter" splitting.000.slcio splitting.001.slcio splitting.002.slcio splitting.003.slcio splitting.004.slcio )
-SET_TESTS_PROPERTIES( t_lcio_event_counter_splitting PROPERTIES PASS_REGULAR_EXPRESSION "10" )
+SET_TESTS_PROPERTIES( t_lcio_event_counter_splitting PROPERTIES PASS_REGULAR_EXPRESSION "40" )
 
 ADD_TEST( t_lcio_split_file_read "${EXECUTABLE_OUTPUT_PATH}/anajob" splitting.000.slcio splitting.001.slcio splitting.002.slcio splitting.003.slcio splitting.004.slcio )
-SET_TESTS_PROPERTIES( t_lcio_split_file_read PROPERTIES PASS_REGULAR_EXPRESSION "10[ ]+events read from files" )
+SET_TESTS_PROPERTIES( t_lcio_split_file_read PROPERTIES PASS_REGULAR_EXPRESSION "40[ ]+events read from files" )
 
 ADD_TEST( t_lcio_event_counter_merged "${EXECUTABLE_OUTPUT_PATH}/lcio_event_counter" merged.slcio )
-SET_TESTS_PROPERTIES( t_lcio_event_counter_merged PROPERTIES PASS_REGULAR_EXPRESSION "10" )
+SET_TESTS_PROPERTIES( t_lcio_event_counter_merged PROPERTIES PASS_REGULAR_EXPRESSION "40" )
 
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- fix the compression level:  use zlib default compression again
        in `SIOWriter` and `MT::LCWriter`
- update the build instructions with ROOT in README.md
       - and set LD_LIBRARY_PATH in setup.sh

ENDRELEASENOTES