### PR TITLE
add optional event meta data in delphes2lcio

### DIFF
--- a/examples/cpp/delphes2lcio/README.md
+++ b/examples/cpp/delphes2lcio/README.md
@@ -1,7 +1,7 @@
 # Delphes2LCIO
 - author: F.Gaede, DESY
 - date June, 2020
-- status: EXPERIMENTAL
+
 
 
 ## Overview
@@ -71,14 +71,15 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LCIO/lib:$DELPHES_DIR/lib
 Then you can run Delphes, e.g. with
 
 ```
-DelphesSTDHEP2LCIO $DELPHES_DIR/cards/delphes_card_ILD.tcl output.slcio input.stdhep
+DelphesSTDHEP2LCIO $DELPHES_DIR/cards/delphes_card_ILC.tcl output.slcio input.stdhep
 ```
 
-**This is just an example delphes card for ILD that does not work really. Better use the 
-generic ILC Delphes card from [https://github.com/iLCSoft/ILCDelphes](https://github.com/iLCSoft/ILCDelphes)**
+**This is requires a recent version of Delphes that has the new ILC card.
+This generic ILC Delphes card can also be downloaded from
+[https://github.com/iLCSoft/ILCDelphes](https://github.com/iLCSoft/ILCDelphes)**
 
 
-This creates an LCIO files with the following default collections:
+This creates an LCIO file with the following default collections:
 
 
 ```
@@ -93,6 +94,9 @@ IsolatedMuons                 ReconstructedParticle        Muon
 PFOs                          ReconstructedParticle        EFlowTrack,EFlowPhoton,EFlowNeutralHadron
 IsolatedPhotons               ReconstructedParticle        Photon
 RecoMCTruthLink               LCRelation                     n.a.
+Durham2Jets                   ReconstructedParticle        Durham2Jets
+...                           ...                          ...
+Durham6Jets                   ReconstructedParticle        Durham6Jets
 ---------------------------------------------------------------------------
 
 ```
@@ -184,8 +188,9 @@ root [0] .x higgs_recoil_plots_fast.C("../build/E250-TDR_ws.Pe2e2h.Gwhizard-1_95
 
 ### Configuration file
 
-The mapping of Delphes branches to LCIO collection by default works for the new ILD delphes card from
-[https://github.com/ILDAnaSoft/ILDDelphes](https://github.com/ILDAnaSoft/ILDDelphes).
+The mapping of Delphes branches to LCIO collection by default works for the new ILC delphes card from
+[https://github.com/iLCSoft/ILCDelphes](https://github.com/iLCSoft/ILCDelphes).
+
 
 If needed, the configuration can be changed, for example if your delphes card produces different output
 branches such as different jet collections.
@@ -218,3 +223,23 @@ These maps for extra jet collections are optional:
 Additional jet collections can be added as long as their name contains the string `"ExtraJet"` and is different from
 all other names. For jet collections the parameter `useDelphes4Vec` defines wether the 4-vector is taken from the delphes
 jet (!=0) or wether it is computed from the jet constituent PFOs (default).
+
+
+
+#### Event Meta data
+
+Event meta data, such as cross sections or polarization data can also be added to the
+configuration file and will then be added to every event as `LCParameters`.
+
+For example add sth. like this at the end of the file:
+
+```
+# --------------------------------
+EventParametersFloat
+CrossSection_fb  1.23456
+beamPol1  1.
+beamPol2 -1.
+Energy  250.
+# --------------------------------
+
+```

--- a/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
+++ b/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
@@ -66,3 +66,19 @@ branchName  Photon
 lcioName  IsolatedPhotons
 pdg  22
 # --------------------------------
+
+#--------------------------------------------------------------------
+# here one can set additional parameters copied to the event header
+#
+# --------------------------------
+##EventParametersFloat
+##CrossSection_fb  1.23456
+##crossSection  1.23456
+##beamPol1  1.
+##beamPol2 -1.
+##Energy  250.
+# --------------------------------
+##EventParametersInt
+# --------------------------------
+##EventParametersString
+# --------------------------------

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -7,10 +7,6 @@
 #include <vector>
 
 
-typedef std::map< std::string, std::string > ConfMap ;
-
-
-
 /** \class DelphesLCIOConfig
  *
  *  Configuration helper class for Delphes to LCIO conversion
@@ -24,6 +20,10 @@ class DelphesLCIOConfig{
 
 public:
   
+  typedef std::map< std::string, std::string > ConfMap ;
+  typedef std::map< std::string, std::string > StringMap ;
+  typedef std::map< std::string, float > FloatMap ;
+  typedef std::map< std::string, int > IntMap ;
 
   /// return parameter for default MCParticle collection
   std::string getMCPParameter(const std::string& key)      const { return getMapParameter( key , "MCParticleMap" ) ; }
@@ -43,6 +43,16 @@ public:
   /// return parameter for default Electron collection
   std::string getElectronParameter(const std::string& key) const { return getMapParameter( key , "ElectronMap" ) ; }
 
+  /// return map of named float parameters, e.g. for event parameters of type float
+  DelphesLCIOConfig::FloatMap getFloatMap(const std::string& mapName) const ;
+
+  /// return map of named int parameters, event parameters of type int
+  DelphesLCIOConfig::IntMap getIntMap(const std::string& mapName) const ;
+
+  /// return map of named string parameters, e.g. for event parameters of type string
+  DelphesLCIOConfig::StringMap getStringMap(const std::string& mapName) const ;
+
+
   /// return list of map names for extra jet collection (containing substring 'ExtraJet' )
   std::vector<std::string> getExtraJetMapNames() const ;
 
@@ -50,7 +60,7 @@ public:
   int toInt(const std::string& val) const ;
 
   /// convert string to float
-  int toFloat(const std::string& val) const ;
+  float toFloat(const std::string& val) const ;
 
   /// return the parameter for the given key from the named map - throws if either does not exist
   std::string getMapParameter(const std::string& key, const std::string& mapName ) const ;

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
@@ -6,6 +6,8 @@
 #include <map>
 #include <functional>
 
+#include "DelphesLCIOConfig.h"
+
 class TTree;
 class TClonesArray;
 class TObject;
@@ -25,8 +27,6 @@ namespace IMPL{
 namespace UTIL{
   class LCRelationNavigator;
 }
-
-class DelphesLCIOConfig ;
 
 
 /** \class DelphesLCIOConverter
@@ -78,7 +78,9 @@ private:
   std::map< unsigned, EVENT::ReconstructedParticle*> _recd2lmap ;
 
   DelphesLCIOConfig* _cfg ;
-
+  DelphesLCIOConfig::FloatMap  _evtParF ; /// optional float event parameters
+  DelphesLCIOConfig::IntMap    _evtParI ; /// optional int event parameters
+  DelphesLCIOConfig::StringMap _evtParS ; /// optional string event parameters
 };
 
 #endif /* DelphesLCIOConverter */

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
@@ -29,11 +29,12 @@ int DelphesLCIOConfig::toInt(const std::string& val) const {
 }
 
 /// convert string to float
-int DelphesLCIOConfig::toFloat(const std::string& val) const {
+float DelphesLCIOConfig::toFloat(const std::string& val) const {
   float f;
   std::stringstream s(val) ; s >> f  ;
   if( s.fail() )
     throw std::runtime_error( std::string("\nDelphesLCIOConfig: cannot convert to float:  ") + val ) ;
+
   return f;
 }
 // ---------------------------------------
@@ -63,6 +64,63 @@ std::string DelphesLCIOConfig::getMapParameterSave(const std::string& key, const
   auto it = m.find( key ) ;
 
   return ( it != m.end() ? it->second : std::string("")  ) ;
+}
+
+// ---------------------------------------
+
+DelphesLCIOConfig::FloatMap DelphesLCIOConfig::getFloatMap(const std::string& mapName) const {
+
+  FloatMap fmap ;
+
+  auto mit = _maps.find( mapName )  ;
+
+  if( mit != _maps.end() ){
+
+    for(auto it : mit->second ){
+
+      fmap[ it.first ] = toFloat( it.second ) ;
+    }
+  }
+
+  return fmap ;
+}
+
+
+DelphesLCIOConfig::IntMap DelphesLCIOConfig::getIntMap(const std::string& mapName) const {
+
+  IntMap imap ;
+
+  auto mit = _maps.find( mapName )  ;
+
+  if( mit != _maps.end() ){
+
+    for(auto it : mit->second ){
+
+      imap[ it.first ] = toInt( it.second ) ;
+    }
+  }
+
+  return imap ;
+
+}
+
+
+DelphesLCIOConfig::StringMap DelphesLCIOConfig::getStringMap(const std::string& mapName) const {
+
+  StringMap smap ;
+
+  auto mit = _maps.find( mapName )  ;
+
+  if( mit != _maps.end() ){
+
+    for(auto it : mit->second ){
+
+      smap[ it.first ] = it.second ;
+    }
+  }
+
+  return smap ;
+
 }
 
 // ---------------------------------------


### PR DESCRIPTION
 BEGINRELEASENOTES
- add optional event meta data in delphes2lcio
      - meta data like cross sections can be added via the configuration file
      - see [../examples/cpp/delphes2lcio/README.md](../examples/cpp/delphes2lcio/README.md) for details


ENDRELEASENOTES