### PR TITLE
Fix decode mc truth process

### DIFF
--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
@@ -655,7 +655,9 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
 
 
 #if LCIO_VERSION_GE( 2 , 15 )
-    ProcessFlag pFlag = decodeMCTruthProcess( mcps ) ;
+    const int maxParticles = 10 ; // defined in ProcessFlag.h
+    int nMCPCheck = maxParticles > mcps->getNumberOfElements() ? mcps->getNumberOfElements()  : maxParticles ;
+    ProcessFlag pFlag = decodeMCTruthProcess( mcps, nMCPCheck ) ;
     evts->setI( ESI::mcproc,  pFlag ) ;
 //    std::cout << " ---- mc truth process : " << pFlag << std::endl ;
 #endif

--- a/src/cpp/src/UTIL/ProcessFlag.cc
+++ b/src/cpp/src/UTIL/ProcessFlag.cc
@@ -32,7 +32,9 @@ namespace UTIL{
     int n_parentless = 0;
     EVENT::MCParticleVec hf_vec;
     
-    for( int i=0 ; i<maxParticles ; ++i){
+    int nP = maxParticles > col->getNumberOfElements() ? col->getNumberOfElements()  : maxParticles ;
+
+    for( int i=0 ; i<nP ; ++i){
       auto* mcp = static_cast<EVENT::MCParticle*>( col->getElementAt(i) ) ;
 
       if( mcp->getGeneratorStatus() == 3 ){


### PR DESCRIPTION

BEGINRELEASENOTES
- fix in UTIL::ProcessFlag::decodeMCTruthProcess
      - protection for events where nMCParticles < 10
- fix also, independently in delphes2lcio

ENDRELEASENOTES