### PR TITLE
add optional extra PFO collections in delphes2lcio

### DIFF
--- a/examples/cpp/delphes2lcio/README.md
+++ b/examples/cpp/delphes2lcio/README.md
@@ -216,13 +216,28 @@ The following maps are required:
 
 - *MCParticleMap, PFOMap, JetMap, MuonMap, ElectronMap, PhotonMap*.
 
-These maps for extra jet collections are optional:
+These maps for extra jet collections are optional (comment out from the configuration file, if not present for your delphes card) :
 
 - *ExtraJetMap2, ExtraJetMap3, ExtraJetMap4, ExtraJetMap5, ExtraJetMap6*.
 
 Additional jet collections can be added as long as their name contains the string `"ExtraJet"` and is different from
 all other names. For jet collections the parameter `useDelphes4Vec` defines wether the 4-vector is taken from the delphes
 jet (!=0) or wether it is computed from the jet constituent PFOs (default).
+
+
+Additional PFO maps can also be added. Their names have to start with `"ExtraPFO"`. For example
+this will create an extra PFO collection called `BCalPFOs` from the Delphes branch `BCalPhoton`
+and assign the photon PDG code:
+
+```
+ExtraPFOMapBCal
+branchName  BCalPhoton
+isCharged  0
+lcioName  BCalPFOs
+mass  0.
+pdg  22
+
+```
 
 
 

--- a/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
+++ b/examples/cpp/delphes2lcio/examples/delphes2lcio.cfg
@@ -66,6 +66,12 @@ branchName  Photon
 lcioName  IsolatedPhotons
 pdg  22
 # --------------------------------
+ExtraPFOMapBCal
+branchName  BCalPhoton
+isCharged  0
+lcioName  BCalPFOs
+mass  0.
+pdg  22
 
 #--------------------------------------------------------------------
 # here one can set additional parameters copied to the event header

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConfig.h
@@ -56,6 +56,9 @@ public:
   /// return list of map names for extra jet collection (containing substring 'ExtraJet' )
   std::vector<std::string> getExtraJetMapNames() const ;
 
+  /// return list of map names for extra jet collection (containing substring 'ExtraPFO' )
+  std::vector<std::string> getExtraPFOMapNames() const ;
+
   /// convert string to int
   int toInt(const std::string& val) const ;
 
@@ -140,8 +143,17 @@ private:
     { "ExtraJetMap3" , { { "lcioName", "Durham3Jets" }, { "branchName", "Jet_N3" }, { "useDelphes4Vec" , "0" }, { "storeYMerge" , "0" } } },
     { "ExtraJetMap4" , { { "lcioName", "Durham4Jets" }, { "branchName", "Jet_N4" }, { "useDelphes4Vec" , "0" }, { "storeYMerge" , "0" } } },
     { "ExtraJetMap5" , { { "lcioName", "Durham5Jets" }, { "branchName", "Jet_N5" }, { "useDelphes4Vec" , "0" }, { "storeYMerge" , "0" } } },
-    { "ExtraJetMap6" , { { "lcioName", "Durham6Jets" }, { "branchName", "Jet_N6" }, { "useDelphes4Vec" , "0" }, { "storeYMerge" , "0" } } }
+    { "ExtraJetMap6" , { { "lcioName", "Durham6Jets" }, { "branchName", "Jet_N6" }, { "useDelphes4Vec" , "0" }, { "storeYMerge" , "0" } } },
 
+    { "ExtraPFOMapBCal" ,
+      {
+	{ "lcioName"          , "BCalPFOs" },
+	{ "branchName"        , "BCalPhoton" },
+	{ "pdg"               , "22" },
+	{ "mass"              , "0." },
+	{ "isCharged"         , "0" },
+      }
+    },
 
   } ;
 

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
@@ -26,7 +26,6 @@ namespace IMPL{
 
 namespace UTIL{
   class LCRelationNavigator;
-  class PIDHandler;
 }
 
 

--- a/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
+++ b/examples/cpp/delphes2lcio/include/DelphesLCIOConverter.h
@@ -26,6 +26,7 @@ namespace IMPL{
 
 namespace UTIL{
   class LCRelationNavigator;
+  class PIDHandler;
 }
 
 
@@ -69,6 +70,18 @@ public:
    *  the Delphes jet is used otherwise it is computed from the constituent PFOs.
    */
   bool convertJetCollection( TClonesArray* tca, EVENT::LCCollection* col, int useDelphes4Vec, int storeYMerge ) ;
+
+  /** Helper function to convert extra charged (Track) particles to ReconstructedParticles (PFOs).
+   *  The new elements are added to the LCIO collection. They will not be linked to the MCParticles as is done
+   *  for the standard PFOs.
+   */
+  int convertExtraPFOsCharged(  TClonesArray* tca, EVENT::LCCollection* col, int pdg, double mass );
+
+  /** Helper function to convert extra neutral (Tower) particles to ReconstructedParticles (PFOs).
+   *  The new elements are added to the LCIO collection. They will not be linked to the MCParticles as is done
+   *  for the standard PFOs.
+   */
+  int convertExtraPFOsNeutral(  TClonesArray* tca, EVENT::LCCollection* col, int pdg, double mass );
 
 private:
   IO::LCWriter *_writer=nullptr;

--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConfig.cc
@@ -11,8 +11,21 @@ std::vector<std::string> DelphesLCIOConfig::getExtraJetMapNames() const {
   std::vector<std::string> ejmapNames ;
 
   for( auto& it : _maps ){
-      
+
     if( ( it.first.find( "ExtraJet" ) != std::string::npos) )
+      ejmapNames.push_back( it.first ) ;
+  }
+  return ejmapNames ;
+}
+
+/// return list of map names for extra PFO collection (containing substring 'ExtraPFO' )
+std::vector<std::string> DelphesLCIOConfig::getExtraPFOMapNames() const {
+
+  std::vector<std::string> ejmapNames ;
+
+  for( auto& it : _maps ){
+
+    if( ( it.first.find( "ExtraPFO" ) != std::string::npos) )
       ejmapNames.push_back( it.first ) ;
   }
   return ejmapNames ;


### PR DESCRIPTION
BEGINRELEASENOTES
- delphes2lcio: add optional extra PFO collections
        - add by default BCalPFOs created from branch BCalPhotons


ENDRELEASENOTES