### PR TITLE
fix nan's in jet 4-momenta (delphes2lcio)

### DIFF
--- a/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
+++ b/examples/cpp/delphes2lcio/src/DelphesLCIOConverter.cc
@@ -384,7 +384,8 @@ void DelphesLCIOConverter::convertTree2LCIO( TTree *tree , lcio::LCEventImpl* ev
       double e = p->E ;
       double th = 2.*atan( exp( - p->Eta ) );
       double ph = p->Phi ;
-      double pp = sqrt( e * e - massNH * massNH ) ;
+      double pp = e ; // sqrt( e * e - massNH * massNH ) ;
+      // create a massless 4-vector to avoid nan's
 
       double m[3] = { pp * cos( ph ) * sin( th ) , pp * sin( ph ) * sin( th ) , pp * cos( th ) } ;
 
@@ -928,7 +929,8 @@ int DelphesLCIOConverter::convertExtraPFOsNeutral(  TClonesArray* tca, EVENT::LC
     double e = p->E ;
     double th = 2.*atan( exp( - p->Eta ) );
     double ph = p->Phi ;
-    double pp = sqrt( e * e - massNH * massNH ) ;
+    double pp = e ; // sqrt( e * e - massNH * massNH ) ;
+    // create a massless 4-vector to avoid nan's
 
     double m[3] = { pp * cos( ph ) * sin( th ) , pp * sin( ph ) * sin( th ) , pp * cos( th ) } ;
 


### PR DESCRIPTION

BEGINRELEASENOTES
- fix in `delphes2lcio` example
     - avoid NANs in jet 4-momenta by using zero mass hyptheses
     - NB: the mass is still set independently to the specified value (following PandoraPFA) 

ENDRELEASENOTES