### PR TITLE
remove const from  map key in LCRTRelations

### DIFF
--- a/src/cpp/include/LCRTRelations.h
+++ b/src/cpp/include/LCRTRelations.h
@@ -493,7 +493,7 @@ namespace lcrtrel{
     // traits definitions
     typedef std::type_index                         ext_index ;
     typedef std::shared_ptr<void>                   ext_type ;
-    typedef std::map<const ext_index, ext_type>     ext_map ;
+    typedef std::map<ext_index, ext_type>     ext_map ;
     
   public:
     /** Provides access to an extension object - the type and ownership is defined 


### PR DESCRIPTION




BEGINRELEASENOTES
- make compatible w/ clang 12 (on MacOs)
    - remove const from map key in LCRTRelations
    - map keys are immutable anyways 

ENDRELEASENOTES