### PR TITLE
Fix deprecated exception warnings

### DIFF
--- a/config/aid.includes.cpp.properties
+++ b/config/aid.includes.cpp.properties
@@ -36,7 +36,7 @@ ShortVec                         = LCIOSTLTypes\.h
 #LCObject                                = LCObject\.h
 EVENT\:\:LCObject			 = EVENT/LCObject\.h
 
-LCRTRelations                            = LCRTRelations\.h
+lcrtrel\:\:LCRTRelations                 = LCRTRelations\.h
 
 
 EVENT\:\:LCIO				= EVENT/LCIO\.h

--- a/config/aid.types.cpp.properties
+++ b/config/aid.types.cpp.properties
@@ -86,6 +86,8 @@ TrackerHitVec                   = EVENT::TrackerHitVec
 LCObjectVec                     = EVENT::LCObjectVec
 
 
+LCRTRelations                   = lcrtrel::LCRTRelations
+
 #long                           = long long
 #long64                          = long64
 

--- a/src/aid/EVENT/LCEvent.aid
+++ b/src/aid/EVENT/LCEvent.aid
@@ -97,6 +97,10 @@ public interface LCEvent {
     /** Parameters defined for this event.
      */
     public LCParameters& parameters() ;
+
+    /** Get the runtime extensions for this event.
+     */
+    public LCRTRelations& runtime() ;
 @endif
 
 

--- a/src/aid/EVENT/LCObject.aid
+++ b/src/aid/EVENT/LCObject.aid
@@ -28,6 +28,11 @@ using namespace lcrtrel ;
 public interface LCObject extends Cloneable, LCRTRelations{
 @ifdef cpp
 
+@cpp{
+  LCObject() = default ;
+  LCObject(const LCObject&) = default ;
+}
+  
     /** Returns an object id for internal (debugging) use in LCIO.
      */
     public int id() const ;

--- a/src/aid/EVENT/Vertex.aid
+++ b/src/aid/EVENT/Vertex.aid
@@ -23,6 +23,10 @@ public interface Vertex extends LCObject {
 
 @ifdef cpp
 @cpp{
+   Vertex() = default ;
+   Vertex(Const Vertex&) = default ;
+}
+@cpp{
     /** Useful typedef for template programming with LCIO */
     typedef Vertex lcobject_type ;
 }

--- a/src/cpp/include/Exceptions.h
+++ b/src/cpp/include/Exceptions.h
@@ -27,13 +27,13 @@ namespace EVENT {
     Exception(){  /*no_op*/ ; } 
     
   public: 
-    virtual ~Exception() throw() { /*no_op*/; } 
+    virtual ~Exception() { /*no_op*/; } 
     
     Exception( const std::string& text ){
       message = "lcio::Exception: " + text ;
     }
 
-    virtual const char* what() const  throw() { return  message.c_str() ; } 
+    virtual const char* what() const noexcept { return  message.c_str() ; } 
 
   };
 
@@ -46,7 +46,7 @@ namespace EVENT {
   protected:
     EventException() {  /*no_op*/ ; } 
   public: 
-    virtual ~EventException() throw() { /*no_op*/; } 
+    virtual ~EventException() { /*no_op*/; } 
 
     EventException( std::string text ){
       message = "lcio::EventException: " + text ;
@@ -60,7 +60,7 @@ namespace EVENT {
   class DataNotAvailableException : public EventException{
 
   public: 
-    virtual ~DataNotAvailableException() throw() { /*no_op*/; } 
+    virtual ~DataNotAvailableException() { /*no_op*/; } 
 
     DataNotAvailableException( std::string text ) {
       message = "lcio::DataNotAvailableException: " + text ;
@@ -74,7 +74,7 @@ namespace EVENT {
   class ReadOnlyException : public EventException{
 
   public: 
-    virtual ~ReadOnlyException() throw() { /*no_op*/; } 
+    virtual ~ReadOnlyException() { /*no_op*/; } 
 
     ReadOnlyException( std::string text ){
       message = "lcio::ReadOnlyException: " + text ;
@@ -107,7 +107,7 @@ namespace IO {
    */
   class EndOfDataException : public IOException{
   public: 
-    virtual ~EndOfDataException() throw() { /*no_op*/; } 
+    virtual ~EndOfDataException() { /*no_op*/; } 
 
     EndOfDataException( std::string text ){
       message = "lcio::EndOfDataException: " + text ;

--- a/src/cpp/include/UTIL/PIDHandler.h
+++ b/src/cpp/include/UTIL/PIDHandler.h
@@ -138,7 +138,7 @@ namespace UTIL{
   protected:
     UnknownAlgorithm() {  /*no_op*/ ; } 
   public: 
-    virtual ~UnknownAlgorithm() throw() { /*no_op*/; } 
+    virtual ~UnknownAlgorithm() { /*no_op*/; } 
     
     UnknownAlgorithm( std::string text ){
       message = "lcio::UnknownAlgorithm: " + text ;


### PR DESCRIPTION
BEGINRELEASENOTES
- fix some warning:
       - deprecated dynamic exception specifications in Exceptions
- fix the build from generated C++ files

ENDRELEASENOTES