### PR TITLE
no longer build lsh example

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -485,14 +485,15 @@ IF( BUILD_LCIO_EXAMPLES )
   ADD_LCIO_EXAMPLE( lcrtrelation )
   ADD_LCIO_EXAMPLE( readcalibration )
 
-  # LCIO SHELL needs curses and readline libraries
-  FIND_PACKAGE( Curses QUIET )
-  FIND_LIBRARY( READLINE_LIBRARY readline PATHS /usr/local/lib64 /usr/local/lib )
-  IF( CURSES_LIBRARY AND READLINE_LIBRARY )
-    ADD_LCIO_EXAMPLE( lsh )
-    TARGET_LINK_LIBRARIES( bin_lsh ${CURSES_LIBRARY} ${READLINE_LIBRARY} )
-  ELSE()
-    MESSAGE( STATUS "cannot build lsh: curses and/or readline libraries not found" )
-  ENDIF()
+## do not build the out-of data lsh example
+##  # LCIO SHELL needs curses and readline libraries
+##  FIND_PACKAGE( Curses QUIET )
+##  FIND_LIBRARY( READLINE_LIBRARY readline PATHS /usr/local/lib64 /usr/local/lib )
+##  IF( CURSES_LIBRARY AND READLINE_LIBRARY )
+##    ADD_LCIO_EXAMPLE( lsh )
+##    TARGET_LINK_LIBRARIES( bin_lsh ${CURSES_LIBRARY} ${READLINE_LIBRARY} )
+##  ELSE()
+##    MESSAGE( STATUS "cannot build lsh: curses and/or readline libraries not found" )
+##  ENDIF()
 ENDIF()
 # ============================================================================

--- a/src/cpp/src/EXAMPLE/lsh.cc
+++ b/src/cpp/src/EXAMPLE/lsh.cc
@@ -4,7 +4,8 @@
  * directory trees.
  * 
  * (developed during DESY summerstudent programme 2007)
- * 
+ *
+ * @deprecated  this code no longer functions fully on some systems
  * @author N. Chiapolini, DESY
  * @version $Id: lsh.cc,v 1.3 2010-04-13 10:58:09 engels Exp $
  */


### PR DESCRIPTION
 - the lsh examples is somewhat out-of-date
   and would need some work
      - does not build w/ newer libreadline
      - has issues w/ direct access 
      - ...
- leave the code in the repo, marked as deprecated, in case someone wants to modernize it


BEGINRELEASENOTES
- no longer build the out-of-date lsh example

ENDRELEASENOTES