### PR TITLE
Random access manager fix

### DIFF
--- a/src/cpp/src/SIO/LCIORandomAccessMgr.cc
+++ b/src/cpp/src/SIO/LCIORandomAccessMgr.cc
@@ -237,7 +237,7 @@ namespace SIO {
       sio::record_info recinfo {} ;
       try {
         sio::api::skip_records( stream, [&]( const sio::record_info &ri ){
-          return ( recordlist.find(ri._name) == recordlist.end() ) ;
+          return ( recordlist.find(ri._name) != recordlist.end() ) ;
         }) ;
         // we read something valid here. Read the record from the stream
         sio::api::read_record( stream, recinfo, _rawBuffer ) ;


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed skip record condition in Random Access Manager

ENDRELEASENOTES

Fixes #128 