### PR TITLE
Deprecate C-API

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,12 @@ jobs:
         run: |
           mkdir build install
           cd build
-          cmake -GNinja -DCMAKE_CXX_STANDARD=17 -DBUILD_ROOTDICT=ON -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" -DCMAKE_INSTALL_PREFIX=../install ..
-          ninja -k0
-          ninja install
+          cmake -DCMAKE_CXX_STANDARD=17 \
+            -DBUILD_ROOTDICT=ON \
+            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DBUILD_F77_TESTJOBS=ON \
+            ..
+          make -k
+          make install
           ctest --output-on-failure

--- a/src/cpp/include/CPPFORT/deprecation.h
+++ b/src/cpp/include/CPPFORT/deprecation.h
@@ -1,0 +1,7 @@
+#ifndef LCIO_CPPFORT_DEPRECATION_MACRO_H
+#define LCIO_CPPFORT_DEPRECATION_MACRO_H
+
+#define LCIO_DEPRECATED_CAPI                              \
+    [[deprecated("C-API of LCIO is deprecated and slated for removal in one of the next releases")]]
+
+#endif

--- a/src/cpp/include/CPPFORT/lccah.h
+++ b/src/cpp/include/CPPFORT/lccah.h
@@ -7,30 +7,33 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lccahcreate() ;
-int lccahdelete( PTRTYPE calhit ) ;
-int lccahid( PTRTYPE calhit ) ;
 
-int lccahgetcellid0( PTRTYPE calhit )  ;
-int lccahgetcellid1( PTRTYPE calhit )  ;
-float lccahgetenergy( PTRTYPE calhit )  ;
-float lccahgetenergyerr( PTRTYPE calhit )  ;
-float lccahgettime( PTRTYPE calhit )  ;
-int lccahgetposition( PTRTYPE calhit, float * )  ;
-int   lccahgettype( PTRTYPE calhit ) ;
-PTRTYPE lccahgetrawhit( PTRTYPE calhit ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lccahcreate() ;
+LCIO_DEPRECATED_CAPI int lccahdelete( PTRTYPE calhit ) ;
+LCIO_DEPRECATED_CAPI int lccahid( PTRTYPE calhit ) ;
 
-int lccahsetcellid0( PTRTYPE calhit, int id0) ;
-int lccahsetcellid1( PTRTYPE calhit, int id1) ;
-int lccahsetenergy( PTRTYPE calhit, float en) ;
-int lccahsetenergyerr( PTRTYPE calhit, float enerr) ;
-int lccahsettime( PTRTYPE calhit, float time) ;
-int lccahsetposition( PTRTYPE calhit, float pos[3])  ;
-int lccahsettype( PTRTYPE calhit, int type ) ;
-int lccahsetrawhit( PTRTYPE calhit, PTRTYPE rawHit ) ;
+LCIO_DEPRECATED_CAPI int lccahgetcellid0( PTRTYPE calhit )  ;
+LCIO_DEPRECATED_CAPI int lccahgetcellid1( PTRTYPE calhit )  ;
+LCIO_DEPRECATED_CAPI float lccahgetenergy( PTRTYPE calhit )  ;
+LCIO_DEPRECATED_CAPI float lccahgetenergyerr( PTRTYPE calhit )  ;
+LCIO_DEPRECATED_CAPI float lccahgettime( PTRTYPE calhit )  ;
+LCIO_DEPRECATED_CAPI int lccahgetposition( PTRTYPE calhit, float * )  ;
+LCIO_DEPRECATED_CAPI int   lccahgettype( PTRTYPE calhit ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lccahgetrawhit( PTRTYPE calhit ) ;
+
+LCIO_DEPRECATED_CAPI int lccahsetcellid0( PTRTYPE calhit, int id0) ;
+LCIO_DEPRECATED_CAPI int lccahsetcellid1( PTRTYPE calhit, int id1) ;
+LCIO_DEPRECATED_CAPI int lccahsetenergy( PTRTYPE calhit, float en) ;
+LCIO_DEPRECATED_CAPI int lccahsetenergyerr( PTRTYPE calhit, float enerr) ;
+LCIO_DEPRECATED_CAPI int lccahsettime( PTRTYPE calhit, float time) ;
+LCIO_DEPRECATED_CAPI int lccahsetposition( PTRTYPE calhit, float pos[3])  ;
+LCIO_DEPRECATED_CAPI int lccahsettype( PTRTYPE calhit, int type ) ;
+LCIO_DEPRECATED_CAPI int lccahsetrawhit( PTRTYPE calhit, PTRTYPE rawHit ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcclu.h
+++ b/src/cpp/include/CPPFORT/lcclu.h
@@ -6,51 +6,53 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcclucreate() ;
-int     lccludelete( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcclucreate() ;
+LCIO_DEPRECATED_CAPI int     lccludelete( PTRTYPE clu ) ;
 
-int     lccluid( PTRTYPE clu ) ;
-int     lcclugettype( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI int     lccluid( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI int     lcclugettype( PTRTYPE clu ) ;
 // int     lcclutesttype( PTRTYPE clu , int bit ) ;
 
-float   lcclugetenergy( PTRTYPE clu ) ;
-float   lcclugetenergyerr( PTRTYPE clu ) ;
-int     lcclugetposition( PTRTYPE clu, float* pos ) ;
-int     lcclugetpositionerror( PTRTYPE clu, float* poserr ) ;
-float   lcclugetitheta( PTRTYPE clu ) ;
-float   lcclugetiphi( PTRTYPE clu ) ;
-int     lcclugetdirectionerror( PTRTYPE clu, float* direrr ) ;
+LCIO_DEPRECATED_CAPI float   lcclugetenergy( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI float   lcclugetenergyerr( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI int     lcclugetposition( PTRTYPE clu, float* pos ) ;
+LCIO_DEPRECATED_CAPI int     lcclugetpositionerror( PTRTYPE clu, float* poserr ) ;
+LCIO_DEPRECATED_CAPI float   lcclugetitheta( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI float   lcclugetiphi( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI int     lcclugetdirectionerror( PTRTYPE clu, float* direrr ) ;
 
 // int     lcclugetshape( PTRTYPE clu, float* shape ) ;
 // int     lcclugetparticletype( PTRTYPE clu, float* weights) ;
 
-PTRTYPE lcclugetshape( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcclugetshape( PTRTYPE clu ) ;
 
-PTRTYPE lcclugetparticleids( PTRTYPE clu ) ;
-PTRTYPE lcclugetclusters( PTRTYPE clu ) ;
-PTRTYPE lcclugetcalorimeterhits( PTRTYPE clu ) ;
-PTRTYPE lcclugetsubdetectorenergies( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcclugetparticleids( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcclugetclusters( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcclugetcalorimeterhits( PTRTYPE clu ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcclugetsubdetectorenergies( PTRTYPE clu ) ;
 
-int     lcclusettypebit( PTRTYPE clu, int index, int val ) ;
-int     lcclusetenergy( PTRTYPE clu, float energy ) ;
-int     lcclusetenergyerr( PTRTYPE clu, float enerr ) ;
-int     lcclusetposition( PTRTYPE clu, float* refpoint ) ;
-int     lcclusetpositionerror( PTRTYPE clu, float* poserr ) ;
-int     lcclusetitheta( PTRTYPE clu, float theta ) ;
-int     lcclusetiphi( PTRTYPE clu, float phi ) ;
-int     lcclusetdirectionerror( PTRTYPE clu, float* direrr ) ;
-int     lcclusetshape( PTRTYPE clu, PTRTYPE pshapevec ) ;
-int     lccluaddparticleid( PTRTYPE clu, PTRTYPE pid ) ;
-int     lccluaddcluster( PTRTYPE clu, PTRTYPE clus ) ;
-int     lccluaddhit( PTRTYPE clu, PTRTYPE calohit, float weigth ) ;
+LCIO_DEPRECATED_CAPI int     lcclusettypebit( PTRTYPE clu, int index, int val ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetenergy( PTRTYPE clu, float energy ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetenergyerr( PTRTYPE clu, float enerr ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetposition( PTRTYPE clu, float* refpoint ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetpositionerror( PTRTYPE clu, float* poserr ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetitheta( PTRTYPE clu, float theta ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetiphi( PTRTYPE clu, float phi ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetdirectionerror( PTRTYPE clu, float* direrr ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetshape( PTRTYPE clu, PTRTYPE pshapevec ) ;
+LCIO_DEPRECATED_CAPI int     lccluaddparticleid( PTRTYPE clu, PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI int     lccluaddcluster( PTRTYPE clu, PTRTYPE clus ) ;
+LCIO_DEPRECATED_CAPI int     lccluaddhit( PTRTYPE clu, PTRTYPE calohit, float weigth ) ;
 
 // fg: these methods have no direct correspondence in the C++ API as there the vector is manipulated
 // directly through the interface
-int     lcclugethitcontributions( PTRTYPE clu, float* ener, int* nener ) ;
-int     lcclusetsubdetectorenergies( PTRTYPE cluster, float* floatv, const int nfloatv ) ;
+LCIO_DEPRECATED_CAPI int     lcclugethitcontributions( PTRTYPE clu, float* ener, int* nener ) ;
+LCIO_DEPRECATED_CAPI int     lcclusetsubdetectorenergies( PTRTYPE cluster, float* floatv, const int nfloatv ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lccol.h
+++ b/src/cpp/include/CPPFORT/lccol.h
@@ -6,27 +6,29 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
 // the collection interface
-PTRTYPE lccolcreate( const char* colname ) ;
-int lccoldelete( PTRTYPE collection ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lccolcreate( const char* colname ) ;
+LCIO_DEPRECATED_CAPI int lccoldelete( PTRTYPE collection ) ;
 
-int lccolgetnumberofelements( PTRTYPE collection ) ;
-char* lccolgettypename( PTRTYPE collection ) ;
-PTRTYPE lccolgetelementat( PTRTYPE collection, int index ) ;
-int lccolgetflag(PTRTYPE collection)  ;
+LCIO_DEPRECATED_CAPI int lccolgetnumberofelements( PTRTYPE collection ) ;
+LCIO_DEPRECATED_CAPI char* lccolgettypename( PTRTYPE collection ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lccolgetelementat( PTRTYPE collection, int index ) ;
+LCIO_DEPRECATED_CAPI int lccolgetflag(PTRTYPE collection)  ;
 
-bool lccolistransient(PTRTYPE collection) ;
-int lccolsettransient(PTRTYPE collection, bool value) ;
+LCIO_DEPRECATED_CAPI bool lccolistransient(PTRTYPE collection) ;
+LCIO_DEPRECATED_CAPI int lccolsettransient(PTRTYPE collection, bool value) ;
 
-bool lccolisdefault(PTRTYPE collection) ;
-int lccolsetdefault(PTRTYPE collection, bool value) ;
+LCIO_DEPRECATED_CAPI bool lccolisdefault(PTRTYPE collection) ;
+LCIO_DEPRECATED_CAPI int lccolsetdefault(PTRTYPE collection, bool value) ;
 
-int lccolsetflag(PTRTYPE collection, int flag) ;
-int lccoladdelement(PTRTYPE collection, PTRTYPE object) ;
-int lccolremoveelementat(PTRTYPE collection, int i)  ;
+LCIO_DEPRECATED_CAPI int lccolsetflag(PTRTYPE collection, int flag) ;
+LCIO_DEPRECATED_CAPI int lccoladdelement(PTRTYPE collection, PTRTYPE object) ;
+LCIO_DEPRECATED_CAPI int lccolremoveelementat(PTRTYPE collection, int i)  ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcevt.h
+++ b/src/cpp/include/CPPFORT/lcevt.h
@@ -8,33 +8,35 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
 // the event interface
-PTRTYPE lcevtcreate() ;
-int     lcevtdelete( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcevtcreate() ;
+LCIO_DEPRECATED_CAPI int     lcevtdelete( PTRTYPE event ) ;
 
-int lcevtgetrunnumber( PTRTYPE event ) ;
-int lcevtgeteventnumber( PTRTYPE event )  ;
-char* lcevtgetdetectorname( PTRTYPE event );
+LCIO_DEPRECATED_CAPI int lcevtgetrunnumber( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI int lcevtgeteventnumber( PTRTYPE event )  ;
+LCIO_DEPRECATED_CAPI char* lcevtgetdetectorname( PTRTYPE event );
 
-long lcevtgettimestamp( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI long lcevtgettimestamp( PTRTYPE event ) ;
 
-PTRTYPE lcevtgetcollectionnames( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcevtgetcollectionnames( PTRTYPE event ) ;
 // PTRTYPE lcevtgettrelationnames( PTRTYPE event ) ;
-PTRTYPE lcevtgetcollection( PTRTYPE event, const char* colname ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcevtgetcollection( PTRTYPE event, const char* colname ) ;
 // PTRTYPE lcevtgetrelation( PTRTYPE event, const char* name ) ;
 
-int lcevtaddcollection(     PTRTYPE event, PTRTYPE collection , char* colname ) ;
-int lcevtremovecollection(  PTRTYPE event, char* name ) ; 
+LCIO_DEPRECATED_CAPI int lcevtaddcollection(     PTRTYPE event, PTRTYPE collection , char* colname ) ;
+LCIO_DEPRECATED_CAPI int lcevtremovecollection(  PTRTYPE event, char* name ) ;
 // int lcevtaddrelation(  PTRTYPE event, PTRTYPE relation, char* name ) ;
 // int lcevtremoverelation( PTRTYPE event, const char* name ) ;
 
-int lcevtsetrunnumber(    PTRTYPE event, int rn ) ;
-int lcevtseteventnumber(  PTRTYPE event, int en ) ;
-int lcevtsetdetectorname( PTRTYPE event, char* dn ) ;
-int lcevtsettimestamp(    PTRTYPE event, long ts ) ;
+LCIO_DEPRECATED_CAPI int lcevtsetrunnumber(    PTRTYPE event, int rn ) ;
+LCIO_DEPRECATED_CAPI int lcevtseteventnumber(  PTRTYPE event, int en ) ;
+LCIO_DEPRECATED_CAPI int lcevtsetdetectorname( PTRTYPE event, char* dn ) ;
+LCIO_DEPRECATED_CAPI int lcevtsettimestamp(    PTRTYPE event, long ts ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcgob.h
+++ b/src/cpp/include/CPPFORT/lcgob.h
@@ -6,29 +6,31 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
 // the genericobject interface
-PTRTYPE lcgobcreate() ;
-PTRTYPE lcgobcreatefixed( int nint, int nfloat, int ndouble ) ;
-int     lcgobdelete( PTRTYPE genericobject ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcgobcreate() ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcgobcreatefixed( int nint, int nfloat, int ndouble ) ;
+LCIO_DEPRECATED_CAPI int     lcgobdelete( PTRTYPE genericobject ) ;
 
-int     lcgobid( PTRTYPE genericobject ) ;
-int     lcgobgetnint( PTRTYPE genericobject ) ;
-int     lcgobgetnfloat( PTRTYPE genericobject ) ;
-int     lcgobgetndouble( PTRTYPE genericobject ) ;
-int     lcgobgetintval( PTRTYPE genericobject, int index ) ;
-float   lcgobgetfloatval( PTRTYPE genericobject, int index ) ;
-double  lcgobgetdoubleval( PTRTYPE genericobject, int index ) ;
+LCIO_DEPRECATED_CAPI int     lcgobid( PTRTYPE genericobject ) ;
+LCIO_DEPRECATED_CAPI int     lcgobgetnint( PTRTYPE genericobject ) ;
+LCIO_DEPRECATED_CAPI int     lcgobgetnfloat( PTRTYPE genericobject ) ;
+LCIO_DEPRECATED_CAPI int     lcgobgetndouble( PTRTYPE genericobject ) ;
+LCIO_DEPRECATED_CAPI int     lcgobgetintval( PTRTYPE genericobject, int index ) ;
+LCIO_DEPRECATED_CAPI float   lcgobgetfloatval( PTRTYPE genericobject, int index ) ;
+LCIO_DEPRECATED_CAPI double  lcgobgetdoubleval( PTRTYPE genericobject, int index ) ;
 
-int     lcgobsetintval( PTRTYPE genericobject, int index, int value) ;
-int     lcgobsetfloatval( PTRTYPE genericobject, int index, float value) ;
-int     lcgobsetdoubleval( PTRTYPE genericobject, int index, double value) ;
+LCIO_DEPRECATED_CAPI int     lcgobsetintval( PTRTYPE genericobject, int index, int value) ;
+LCIO_DEPRECATED_CAPI int     lcgobsetfloatval( PTRTYPE genericobject, int index, float value) ;
+LCIO_DEPRECATED_CAPI int     lcgobsetdoubleval( PTRTYPE genericobject, int index, double value) ;
 
-bool    lcgobisfixedsize(PTRTYPE genericobject) ;
-char*   lcgobgettypename(PTRTYPE genericobject) ;
-char*   lcgobgetdatadescription(PTRTYPE genericobject) ;
+LCIO_DEPRECATED_CAPI bool    lcgobisfixedsize(PTRTYPE genericobject) ;
+LCIO_DEPRECATED_CAPI char*   lcgobgettypename(PTRTYPE genericobject) ;
+LCIO_DEPRECATED_CAPI char*   lcgobgetdatadescription(PTRTYPE genericobject) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lciof77apiext.h
+++ b/src/cpp/include/CPPFORT/lciof77apiext.h
@@ -14,65 +14,66 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
 
 //--------------- convenient method to open a list of files for reading (read-only)
 
 /**Opens a list of files for reading (read-only).
  */
-int lcrdropenchain( PTRTYPE reader, void* filenamesv, const int nfiles, const int nchfilename );
+LCIO_DEPRECATED_CAPI int lcrdropenchain( PTRTYPE reader, void* filenamesv, const int nfiles, const int nchfilename );
 
 //--------------- convenient methods to read/write the run header
 
 /**Write a run header to the specified writer with the given data.
  */
-int lcwriterunheader( PTRTYPE writer, const int irun, const char* detname, const char* descr,
+LCIO_DEPRECATED_CAPI int lcwriterunheader( PTRTYPE writer, const int irun, const char* detname, const char* descr,
                          void* sdnamevec, const int nsubd, const int nchsubd) ;
 
 /**Read the next run header and fills the return arguments with the data.
  */
-PTRTYPE lcreadnextrunheader( PTRTYPE reader, int* irun, void* detname, void* descr,
+LCIO_DEPRECATED_CAPI PTRTYPE lcreadnextrunheader( PTRTYPE reader, int* irun, void* detname, void* descr,
                             void* sdnamevec, int* nsubd, const int nchsubd) ;
 
 //---------------  convenient methods for the event interface
 
 /**Set the complete event header data in the event.
  */
-int lcseteventheader( PTRTYPE event, const int irun, const int ievent, 
+LCIO_DEPRECATED_CAPI int lcseteventheader( PTRTYPE event, const int irun, const int ievent,
 		      const int timestamp, const char* detname );
 
 /**Read the complete event header data from the event.
  */
-int lcgeteventheader( PTRTYPE event, int* irun, int* ievent, int* timestamp, void* detname );
+LCIO_DEPRECATED_CAPI int lcgeteventheader( PTRTYPE event, int* irun, int* ievent, int* timestamp, void* detname );
 
 /**Dump the run header to the stdout 
  */
-int lcdumprunheader( PTRTYPE runheader ) ;
+LCIO_DEPRECATED_CAPI int lcdumprunheader( PTRTYPE runheader ) ;
 
 /**Dump the event to the stdout - one line per collection.
  */
-int lcdumpevent( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI int lcdumpevent( PTRTYPE event ) ;
 
 /**Detailed dump of all the data in the event to stdout.
  */
-int lcdumpeventdetailed( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI int lcdumpeventdetailed( PTRTYPE event ) ;
 
 //---------------  convenient methods for the mcparticle interface
 
 
 /**Return all the data of the specified MCParticle in the arguments.
  */
-int lcgetmcparticledata( PTRTYPE mcparticle, int* pdg, int* genstatus, int* simstatus
+LCIO_DEPRECATED_CAPI int lcgetmcparticledata( PTRTYPE mcparticle, int* pdg, int* genstatus, int* simstatus
 			 , double* prodvtx, float* momentum, float* mass, float* charge, 
 			 int* ndaughters ) ;
 
 
 /**Fill the hepevt common block with the MCParicle data in the LCIO event.
  */
-int lcio2hepevt( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI int lcio2hepevt( PTRTYPE event ) ;
 
 /**Create an MCParticle collection from the hepevt common block and add it to the event.
  */
-int hepevt2lcio( PTRTYPE event ) ;
+LCIO_DEPRECATED_CAPI int hepevt2lcio( PTRTYPE event ) ;
 
 
 
@@ -80,12 +81,12 @@ int hepevt2lcio( PTRTYPE event ) ;
 
 /**Add a new SimTrackerHit with the given data to the collection.
  */
-int lcaddsimtrackerhit( PTRTYPE col, int cellID, double* pos, float dEdx,
+LCIO_DEPRECATED_CAPI int lcaddsimtrackerhit( PTRTYPE col, int cellID, double* pos, float dEdx,
 			    float time, PTRTYPE mcp ) ;
 
 /**Return all the data from the specified SimTrackerHit in the arguments.
  */
-int lcgetsimtrackerhit( PTRTYPE col, int i, int* cellID, double* pos, float* dEdx, 
+LCIO_DEPRECATED_CAPI int lcgetsimtrackerhit( PTRTYPE col, int i, int* cellID, double* pos, float* dEdx,
 			    float* time, PTRTYPE* mcp ) ;
 
 
@@ -94,84 +95,84 @@ int lcgetsimtrackerhit( PTRTYPE col, int i, int* cellID, double* pos, float* dEd
 /**Add a new SimCalorimeterHit with the given data to the collection.
  * Returns a pointer the new hit.
  */
-PTRTYPE lcaddsimcalohit( PTRTYPE col, int cellID0, int cellID1, float energy, float* pos ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcaddsimcalohit( PTRTYPE col, int cellID0, int cellID1, float energy, float* pos ) ;
 
 /**Return the data of the specified SimCalorimeterHit in the arguments.
  */
-PTRTYPE lcgetsimcalohit( PTRTYPE col, int i, int* cellID0, int* cellID1, float* energy,
+LCIO_DEPRECATED_CAPI PTRTYPE lcgetsimcalohit( PTRTYPE col, int i, int* cellID0, int* cellID1, float* energy,
 			 float* pos ) ;
 
 /**Return the specified contribution of a MCParticle to the hit in the arguments.
  */
-int lcgetsimcalohitmccont( PTRTYPE hit, int i, PTRTYPE* mcp, float* energy, float* time, 
+LCIO_DEPRECATED_CAPI int lcgetsimcalohitmccont( PTRTYPE hit, int i, PTRTYPE* mcp, float* energy, float* time,
 			     int* pdg ) ;
 
 
 /**Create an object vector
 */
-PTRTYPE lcobjectvectorcreate( PTRTYPE* ocjectv, const int nobjv ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcobjectvectorcreate( PTRTYPE* ocjectv, const int nobjv ) ;
 
 /**Create an LC int vector
 */
-PTRTYPE lcintvectorcreate( int* intv, const int nintv ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcintvectorcreate( int* intv, const int nintv ) ;
 
 /**Create a LC float vector
 */
-PTRTYPE lcfloatvectorcreate( float* floatv, const int nfloatv ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcfloatvectorcreate( float* floatv, const int nfloatv ) ;
 
 /**Create a LC string vector
 */
-PTRTYPE lcstringvectorcreate( void* stringv, const int nstringv, const int nchstringv) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcstringvectorcreate( void* stringv, const int nstringv, const int nchstringv) ;
 
 /**Return the content of a LC int vector
 */
-int lcgetintvector( PTRTYPE vector, int* intv, int* nintv ) ;
+LCIO_DEPRECATED_CAPI int lcgetintvector( PTRTYPE vector, int* intv, int* nintv ) ;
 
 /**Return the content of a LC float vector
 */
-int lcgetfloatvector( PTRTYPE vector, float* floatv, int* nfloatv ) ;
+LCIO_DEPRECATED_CAPI int lcgetfloatvector( PTRTYPE vector, float* floatv, int* nfloatv ) ;
 
 /**Return the content of a LC string vector
 */
-int lcgetstringvector( PTRTYPE vector, void* stringv, int* nstringv, const int nchstringv) ;
+LCIO_DEPRECATED_CAPI int lcgetstringvector( PTRTYPE vector, void* stringv, int* nstringv, const int nchstringv) ;
 
                   
 /**Create/Delete an int vector
 */
-PTRTYPE intvectorcreate( int* intv, const int nintv ) ;
-int intvectordelete( PTRTYPE vector ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE intvectorcreate( int* intv, const int nintv ) ;
+LCIO_DEPRECATED_CAPI int intvectordelete( PTRTYPE vector ) ;
 
 /**Create/Delete a float vector
 */
-PTRTYPE floatvectorcreate( float* floatv, const int nfloatv ) ;
-int floatvectordelete( PTRTYPE vector ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE floatvectorcreate( float* floatv, const int nfloatv ) ;
+LCIO_DEPRECATED_CAPI int floatvectordelete( PTRTYPE vector ) ;
 
 /**Create/Delete a string vector
 */
-PTRTYPE stringvectorcreate( void* stringv, const int nstringv, const int nchstringv) ;
-int stringvectordelete( PTRTYPE vector ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE stringvectorcreate( void* stringv, const int nstringv, const int nchstringv) ;
+LCIO_DEPRECATED_CAPI int stringvectordelete( PTRTYPE vector ) ;
                   
 /**Create/Delete a pointer vector
 */
-PTRTYPE pointervectorcreate( PTRTYPE* pointerv, const int npointerv ) ;
-int pointervectordelete( PTRTYPE vector ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE pointervectorcreate( PTRTYPE* pointerv, const int npointerv ) ;
+LCIO_DEPRECATED_CAPI int pointervectordelete( PTRTYPE vector ) ;
 
 
 /**Return the content of an int vector
 */
-int getintvector( PTRTYPE vector, int* intv, int* nintv ) ;
+LCIO_DEPRECATED_CAPI int getintvector( PTRTYPE vector, int* intv, int* nintv ) ;
 
 /**Return the content of a float vector
 */
-int getfloatvector( PTRTYPE vector, float* floatv, int* nfloatv ) ;
+LCIO_DEPRECATED_CAPI int getfloatvector( PTRTYPE vector, float* floatv, int* nfloatv ) ;
 
 /**Return the content of a string vector
 */
-int getstringvector( PTRTYPE vector, void* stringv, int* nstringv, const int nchstringv) ;
+LCIO_DEPRECATED_CAPI int getstringvector( PTRTYPE vector, void* stringv, int* nstringv, const int nchstringv) ;
 
 /**Return the content of a pointer vector
 */
-int getpointervector( PTRTYPE vector, PTRTYPE* pointerv, int* npointerv ) ;
+LCIO_DEPRECATED_CAPI int getpointervector( PTRTYPE vector, PTRTYPE* pointerv, int* npointerv ) ;
 
 
 
@@ -180,13 +181,13 @@ int getpointervector( PTRTYPE vector, PTRTYPE* pointerv, int* npointerv ) ;
 
 /**For the set methods:
 */
-int lcsetparameters( const char* classname, PTRTYPE classp, const char* method,
+LCIO_DEPRECATED_CAPI int lcsetparameters( const char* classname, PTRTYPE classp, const char* method,
 			    const char* key, PTRTYPE vecp) ;
 
 
 /**For the get methods:
 */
-int lcgetparameters( const char* classname, PTRTYPE classp, const char* method,
+LCIO_DEPRECATED_CAPI int lcgetparameters( const char* classname, PTRTYPE classp, const char* method,
 			    const char* key, PTRTYPE vecp) ;
 
 

--- a/src/cpp/include/CPPFORT/lcmcp.h
+++ b/src/cpp/include/CPPFORT/lcmcp.h
@@ -6,42 +6,44 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcmcpcreate() ;
-int lcmcpdelete( PTRTYPE mcparticle ) ;
-int lcmcpgetnumberofparents( PTRTYPE mcparticle )  ;
-PTRTYPE lcmcpgetparent( PTRTYPE mcparticle , int i ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcmcpcreate() ;
+LCIO_DEPRECATED_CAPI int lcmcpdelete( PTRTYPE mcparticle ) ;
+LCIO_DEPRECATED_CAPI int lcmcpgetnumberofparents( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcmcpgetparent( PTRTYPE mcparticle , int i ) ;
 // PTRTYPE lcmcpgetsecondparent( PTRTYPE mcparticle ) ;
-PTRTYPE lcmcpgetdaughter( PTRTYPE mcparticle, int i ) ;
-int lcmcpgetendpoint(  PTRTYPE mcparticle, double* ep) ;
-int lcmcpgetnumberofdaughters( PTRTYPE mcparticle )  ;
-int lcmcpgetpdg( PTRTYPE mcparticle )  ;
-int lcmcpgetgeneratorstatus( PTRTYPE mcparticle )  ;
-int lcmcpgetsimulatorstatus( PTRTYPE mcparticle )  ;
-int lcmcpgetvertex( PTRTYPE mcparticle, double* vtx )  ;
-float lcmcpgettime( PTRTYPE mcparticle )  ;
-int lcmcpgetmomentum( PTRTYPE mcparticle, double* p)  ;
-double lcmcpgetmass( PTRTYPE mcparticle )  ;
-float lcmcpgetcharge( PTRTYPE mcparticle )  ;
-double lcmcpgetenergy( PTRTYPE mcparticle )  ;
-int lcmcpgetspin( PTRTYPE mcparticle, float* spin ) ;
-int lcmcpgetcolorflow( PTRTYPE mcparticle, int* cflow ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcmcpgetdaughter( PTRTYPE mcparticle, int i ) ;
+LCIO_DEPRECATED_CAPI int lcmcpgetendpoint(  PTRTYPE mcparticle, double* ep) ;
+LCIO_DEPRECATED_CAPI int lcmcpgetnumberofdaughters( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI int lcmcpgetpdg( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI int lcmcpgetgeneratorstatus( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI int lcmcpgetsimulatorstatus( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI int lcmcpgetvertex( PTRTYPE mcparticle, double* vtx )  ;
+LCIO_DEPRECATED_CAPI float lcmcpgettime( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI int lcmcpgetmomentum( PTRTYPE mcparticle, double* p)  ;
+LCIO_DEPRECATED_CAPI double lcmcpgetmass( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI float lcmcpgetcharge( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI double lcmcpgetenergy( PTRTYPE mcparticle )  ;
+LCIO_DEPRECATED_CAPI int lcmcpgetspin( PTRTYPE mcparticle, float* spin ) ;
+LCIO_DEPRECATED_CAPI int lcmcpgetcolorflow( PTRTYPE mcparticle, int* cflow ) ;
 
-int lcmcpaddparent(  PTRTYPE mcparticle, PTRTYPE parent ) ;
+LCIO_DEPRECATED_CAPI int lcmcpaddparent(  PTRTYPE mcparticle, PTRTYPE parent ) ;
 // int lcmcpsetsecondparent(  PTRTYPE mcparticle, PTRTYPE parent ) ;
 // int lcmcpadddaughter(  PTRTYPE mcparticle, PTRTYPE daughter ) ;
-int lcmcpsetpdg( PTRTYPE mcparticle, int pdg ) ;
-int lcmcpsetgeneratorstatus( PTRTYPE mcparticle, int status ) ;
-int lcmcpsetsimulatorstatus( PTRTYPE mcparticle, int status ) ;
-int lcmcpsetvertex( PTRTYPE mcparticle, double vtx[3] ) ;
-int lcmcpsetendpoint( PTRTYPE mcparticle, double pnt[3] ) ;
-int lcmcpsetmomentum( PTRTYPE mcparticle,  float p[3] );
-int lcmcpsetmass( PTRTYPE mcparticle, float m) ;
-int lcmcpsetcharge( PTRTYPE mcparticle, float c ) ;
-int lcmcpsetspin( PTRTYPE mcparticle, float spin[3] ) ;
-int lcmcpsetcolorflow( PTRTYPE mcparticle, int cflow[2] ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetpdg( PTRTYPE mcparticle, int pdg ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetgeneratorstatus( PTRTYPE mcparticle, int status ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetsimulatorstatus( PTRTYPE mcparticle, int status ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetvertex( PTRTYPE mcparticle, double vtx[3] ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetendpoint( PTRTYPE mcparticle, double pnt[3] ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetmomentum( PTRTYPE mcparticle,  float p[3] );
+LCIO_DEPRECATED_CAPI int lcmcpsetmass( PTRTYPE mcparticle, float m) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetcharge( PTRTYPE mcparticle, float c ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetspin( PTRTYPE mcparticle, float spin[3] ) ;
+LCIO_DEPRECATED_CAPI int lcmcpsetcolorflow( PTRTYPE mcparticle, int cflow[2] ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcobv.h
+++ b/src/cpp/include/CPPFORT/lcobv.h
@@ -7,14 +7,16 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
 // the RelationNavigator interface
-int lcobvgetlength( PTRTYPE vector ) ;
-PTRTYPE lcobvgetobject( PTRTYPE vector, int index ) ;
-int lcobvgetobjectid( PTRTYPE vector, int index ) ;
-float lcobvgetweight( PTRTYPE vector, int index ) ;
+LCIO_DEPRECATED_CAPI int lcobvgetlength( PTRTYPE vector ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcobvgetobject( PTRTYPE vector, int index ) ;
+LCIO_DEPRECATED_CAPI int lcobvgetobjectid( PTRTYPE vector, int index ) ;
+LCIO_DEPRECATED_CAPI float lcobvgetweight( PTRTYPE vector, int index ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcpid.h
+++ b/src/cpp/include/CPPFORT/lcpid.h
@@ -6,26 +6,28 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcpidcreate() ;
-int     lcpiddelete( PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcpidcreate() ;
+LCIO_DEPRECATED_CAPI int     lcpiddelete( PTRTYPE pid ) ;
 
-int     lcpidid( PTRTYPE pid ) ;
-int     lcpidgettype( PTRTYPE pid ) ;
-int     lcpidgetpdg( PTRTYPE pid ) ;
-float   lcpidgetlikelihood( PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI int     lcpidid( PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI int     lcpidgettype( PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI int     lcpidgetpdg( PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI float   lcpidgetlikelihood( PTRTYPE pid ) ;
 
-int     lcpidgetalgorithmtype( PTRTYPE pid ) ;
-int     lcpidgetparameters( PTRTYPE pid, float* vec, int* nvec ) ;
+LCIO_DEPRECATED_CAPI int     lcpidgetalgorithmtype( PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI int     lcpidgetparameters( PTRTYPE pid, float* vec, int* nvec ) ;
 
-int     lcpidsettype( PTRTYPE pid, int type ) ;
-int     lcpidsetpdg( PTRTYPE pid, int pdg ) ;
-int     lcpidsetlikelihood( PTRTYPE pid, float logl ) ;
+LCIO_DEPRECATED_CAPI int     lcpidsettype( PTRTYPE pid, int type ) ;
+LCIO_DEPRECATED_CAPI int     lcpidsetpdg( PTRTYPE pid, int pdg ) ;
+LCIO_DEPRECATED_CAPI int     lcpidsetlikelihood( PTRTYPE pid, float logl ) ;
 
-int     lcpidsetalgorithmtype( PTRTYPE pid, int algo ) ;
-int     lcpidaddparameter( PTRTYPE pid, float param ) ;
+LCIO_DEPRECATED_CAPI int     lcpidsetalgorithmtype( PTRTYPE pid, int algo ) ;
+LCIO_DEPRECATED_CAPI int     lcpidaddparameter( PTRTYPE pid, float param ) ;
 
 
 // now the fortran wrappers from cfortran.h              

--- a/src/cpp/include/CPPFORT/lcrcp.h
+++ b/src/cpp/include/CPPFORT/lcrcp.h
@@ -6,50 +6,52 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcrcpcreate() ;
-int     lcrcpdelete( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrcpcreate() ;
+LCIO_DEPRECATED_CAPI int     lcrcpdelete( PTRTYPE rcp ) ;
 
-int     lcrcpid( PTRTYPE rcp ) ;
-int     lcrcpgettype( PTRTYPE rcp ) ;
-bool    lcrcpiscompound( PTRTYPE rcp ) ;
-int     lcrcpgetmomentum( PTRTYPE rcp, float* p ) ;
-float   lcrcpgetenergy( PTRTYPE rcp ) ;
-int     lcrcpgetcovmatrix( PTRTYPE rcp, float* cvmtx ) ;
-float   lcrcpgetmass( PTRTYPE rcp ) ;
-float   lcrcpgetcharge( PTRTYPE rcp ) ;
-int     lcrcpgetreferencepoint( PTRTYPE rcp, float* refpoint ) ;
-PTRTYPE lcrcpgetparticleids( PTRTYPE rcp ) ;
-float   lcrcpgetgoodnessofpid( PTRTYPE pid ) ;
-PTRTYPE lcrcpgetparticles( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpid( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpgettype( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI bool    lcrcpiscompound( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpgetmomentum( PTRTYPE rcp, float* p ) ;
+LCIO_DEPRECATED_CAPI float   lcrcpgetenergy( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpgetcovmatrix( PTRTYPE rcp, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI float   lcrcpgetmass( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI float   lcrcpgetcharge( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpgetreferencepoint( PTRTYPE rcp, float* refpoint ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrcpgetparticleids( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI float   lcrcpgetgoodnessofpid( PTRTYPE pid ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrcpgetparticles( PTRTYPE rcp ) ;
 // int     lcrcpgetparticleweights( PTRTYPE rcp, float* weights, int* nweights ) ;
-PTRTYPE lcrcpgetclusters( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrcpgetclusters( PTRTYPE rcp ) ;
 // int     lcrcpgetclusterweights( PTRTYPE rcp, float* weights, int* nweights ) ;
-PTRTYPE lcrcpgettracks( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrcpgettracks( PTRTYPE rcp ) ;
 // int     lcrcpgettrackweights( PTRTYPE rcp, float* weights, int* nweights ) ;
 // PTRTYPE lcrcpgetmcparticles( PTRTYPE rcp ) ;
 // int     lcrcpgetmcparticleweights( PTRTYPE rcp, float* weights, int* nweights ) ;
-PTRTYPE lcrcpgetstartvertex( PTRTYPE rcp ) ;
-PTRTYPE lcrcpgetendvertex( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrcpgetstartvertex( PTRTYPE rcp ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrcpgetendvertex( PTRTYPE rcp ) ;
 
 
-int     lcrcpsettype( PTRTYPE rcp, int type ) ;
-int     lcrcpsetcompound( PTRTYPE rcp, bool lcompound ) ;
-int     lcrcpsetmomentum( PTRTYPE rcp, float* p ) ;
-int     lcrcpsetenergy( PTRTYPE rcp, float energy ) ;
-int     lcrcpsetcovmatrix( PTRTYPE rcp, float* cvmtx ) ;
-int     lcrcpsetmass( PTRTYPE rcp, float xmass) ;
-int     lcrcpsetcharge( PTRTYPE rcp, float charge ) ;
-int     lcrcpsetreferencepoint( PTRTYPE rcp, float* refpoint ) ;
-int     lcrcpaddparticleid( PTRTYPE rcp, PTRTYPE id ) ;
-int     lcrcpsetgoodnessofpid( PTRTYPE pid, float good ) ;
-int     lcrcpaddparticle( PTRTYPE rcp, PTRTYPE particle ) ;
-int     lcrcpaddcluster( PTRTYPE rcp, PTRTYPE clus ) ;
-int     lcrcpaddtrack( PTRTYPE rcp, PTRTYPE track) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsettype( PTRTYPE rcp, int type ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetcompound( PTRTYPE rcp, bool lcompound ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetmomentum( PTRTYPE rcp, float* p ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetenergy( PTRTYPE rcp, float energy ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetcovmatrix( PTRTYPE rcp, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetmass( PTRTYPE rcp, float xmass) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetcharge( PTRTYPE rcp, float charge ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetreferencepoint( PTRTYPE rcp, float* refpoint ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpaddparticleid( PTRTYPE rcp, PTRTYPE id ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetgoodnessofpid( PTRTYPE pid, float good ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpaddparticle( PTRTYPE rcp, PTRTYPE particle ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpaddcluster( PTRTYPE rcp, PTRTYPE clus ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpaddtrack( PTRTYPE rcp, PTRTYPE track) ;
 // int     lcrcpaddmcparticle( PTRTYPE rcp, PTRTYPE mcp, float weigth ) ;
-int     lcrcpsetstartvertex( PTRTYPE rcp, PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI int     lcrcpsetstartvertex( PTRTYPE rcp, PTRTYPE vtx ) ;
                                                   
 
 // now the fortran wrappers from cfortran.h

--- a/src/cpp/include/CPPFORT/lcrdr.h
+++ b/src/cpp/include/CPPFORT/lcrdr.h
@@ -8,21 +8,23 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcrdrcreate() ;
-int     lcrdrdelete( PTRTYPE reader ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrdrcreate() ;
+LCIO_DEPRECATED_CAPI int     lcrdrdelete( PTRTYPE reader ) ;
 
-int   lcrdropen( PTRTYPE reader, const char* filename ) ;
-int   lcrdrclose( PTRTYPE reader ) ;
-int   lcrdrreadstream( PTRTYPE reader, int maxRecord ) ;
+LCIO_DEPRECATED_CAPI int   lcrdropen( PTRTYPE reader, const char* filename ) ;
+LCIO_DEPRECATED_CAPI int   lcrdrclose( PTRTYPE reader ) ;
+LCIO_DEPRECATED_CAPI int   lcrdrreadstream( PTRTYPE reader, int maxRecord ) ;
 
-PTRTYPE lcrdrreadnextrunheader(PTRTYPE reader, int accessMode) ;
-PTRTYPE lcrdrreadnextevent(PTRTYPE reader, int accessMode) ;
-PTRTYPE lcrdrreadevent(PTRTYPE reader, int runNumber, int evtNumber );
+LCIO_DEPRECATED_CAPI PTRTYPE lcrdrreadnextrunheader(PTRTYPE reader, int accessMode) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrdrreadnextevent(PTRTYPE reader, int accessMode) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrdrreadevent(PTRTYPE reader, int runNumber, int evtNumber );
 
-int  lcrdrskipnevents( PTRTYPE reader, int n ) ;
+LCIO_DEPRECATED_CAPI int  lcrdrskipnevents( PTRTYPE reader, int n ) ;
 
 extern "C"{
 

--- a/src/cpp/include/CPPFORT/lcrdrrep.h
+++ b/src/cpp/include/CPPFORT/lcrdrrep.h
@@ -21,11 +21,12 @@
 #include "IMPL/LCRunHeaderImpl.h"
 #include "IMPL/LCEventImpl.h"
 
+#include "deprecation.h"
 
 //--------------- convenient method to open a file and process it by the RunEventProcessor class
 /**Opens a file for reading, register run and event listener, and process the input stream
  */
-int lcrdreventprocessor( PTRTYPE filenamevec ) ;
+LCIO_DEPRECATED_CAPI int lcrdreventprocessor( PTRTYPE filenamevec ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcrel.h
+++ b/src/cpp/include/CPPFORT/lcrel.h
@@ -7,22 +7,24 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
 // the relation interface
-PTRTYPE lcrelcreate0() ;
-PTRTYPE lcrelcreate( PTRTYPE objectfrom, PTRTYPE objectto, float weight ) ;
-int lcreldelete( PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrelcreate0() ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrelcreate( PTRTYPE objectfrom, PTRTYPE objectto, float weight ) ;
+LCIO_DEPRECATED_CAPI int lcreldelete( PTRTYPE relation ) ;
 
-int lcrelid(PTRTYPE relation) ;
-PTRTYPE lcrelgetfrom( PTRTYPE relation ) ;
-PTRTYPE lcrelgetto( PTRTYPE relation ) ;
-float lcrelgetweight( PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI int lcrelid(PTRTYPE relation) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrelgetfrom( PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrelgetto( PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI float lcrelgetweight( PTRTYPE relation ) ;
                
-int lcrelsetfrom(PTRTYPE relation, PTRTYPE object ) ;
-int lcrelsetto(PTRTYPE relation, PTRTYPE object ) ;
-int lcrelsetweight(PTRTYPE relation,float weight ) ;
+LCIO_DEPRECATED_CAPI int lcrelsetfrom(PTRTYPE relation, PTRTYPE object ) ;
+LCIO_DEPRECATED_CAPI int lcrelsetto(PTRTYPE relation, PTRTYPE object ) ;
+LCIO_DEPRECATED_CAPI int lcrelsetweight(PTRTYPE relation,float weight ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcrhd.h
+++ b/src/cpp/include/CPPFORT/lcrhd.h
@@ -7,23 +7,25 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcrhdcreate() ;
-int lcrhddelete( PTRTYPE runHeader ) ;
-int lcrhdgetrunnumber( PTRTYPE runHeader )  ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrhdcreate() ;
+LCIO_DEPRECATED_CAPI int lcrhddelete( PTRTYPE runHeader ) ;
+LCIO_DEPRECATED_CAPI int lcrhdgetrunnumber( PTRTYPE runHeader )  ;
 
-char* lcrhdgetdetectorname( PTRTYPE runHeader  ) ;
-char* lcrhdgetdescription( PTRTYPE runHeader )  ;
+LCIO_DEPRECATED_CAPI char* lcrhdgetdetectorname( PTRTYPE runHeader  ) ;
+LCIO_DEPRECATED_CAPI char* lcrhdgetdescription( PTRTYPE runHeader )  ;
 
-PTRTYPE lcrhdgetactivesubdetectors(PTRTYPE runHeader) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrhdgetactivesubdetectors(PTRTYPE runHeader) ;
 
-int lcrhdsetrunnumber( PTRTYPE runHeader, int rn) ;
-int lcrhdsetdetectorname( PTRTYPE runHeader, const char* dn) ;
-int lcrhdsetdescription( PTRTYPE runHeader, const char* dsc) ;
-int lcrhdaddactivesubdetector( PTRTYPE runHeader, const char* adn) ;
+LCIO_DEPRECATED_CAPI int lcrhdsetrunnumber( PTRTYPE runHeader, int rn) ;
+LCIO_DEPRECATED_CAPI int lcrhdsetdetectorname( PTRTYPE runHeader, const char* dn) ;
+LCIO_DEPRECATED_CAPI int lcrhdsetdescription( PTRTYPE runHeader, const char* dsc) ;
+LCIO_DEPRECATED_CAPI int lcrhdaddactivesubdetector( PTRTYPE runHeader, const char* adn) ;
 
 
 // now the fortran wrappers from cfortran.h

--- a/src/cpp/include/CPPFORT/lcrnv.h
+++ b/src/cpp/include/CPPFORT/lcrnv.h
@@ -7,24 +7,26 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
 // the RelationNavigator interface
-PTRTYPE lcrnvcreate( const char* fromType, const char* toType ) ;
-int lcrnvdelete( PTRTYPE relation ) ;
-PTRTYPE lcrnvcreatefromcollection( PTRTYPE collection ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrnvcreate( const char* fromType, const char* toType ) ;
+LCIO_DEPRECATED_CAPI int lcrnvdelete( PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrnvcreatefromcollection( PTRTYPE collection ) ;
 
-char* lcrnvgetfromtype( PTRTYPE relation ) ;
-char* lcrnvgettotype( PTRTYPE relation ) ;
-PTRTYPE lcrnvgetrelatedtoobjects( PTRTYPE relation, PTRTYPE object ) ;
-PTRTYPE lcrnvgetrelatedfromobjects( PTRTYPE relation, PTRTYPE object ) ;
-PTRTYPE lcrnvgetrelatedtoweights ( PTRTYPE relation, PTRTYPE object ) ;
-PTRTYPE lcrnvgetrelatedfromweights ( PTRTYPE relation, PTRTYPE object ) ;
+LCIO_DEPRECATED_CAPI char* lcrnvgetfromtype( PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI char* lcrnvgettotype( PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrnvgetrelatedtoobjects( PTRTYPE relation, PTRTYPE object ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrnvgetrelatedfromobjects( PTRTYPE relation, PTRTYPE object ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrnvgetrelatedtoweights ( PTRTYPE relation, PTRTYPE object ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrnvgetrelatedfromweights ( PTRTYPE relation, PTRTYPE object ) ;
 
-int lcrnvgaddrelation(PTRTYPE relation, PTRTYPE objectfrom, PTRTYPE objectto, float weight ) ;
-int lcrnvgremoverelation(PTRTYPE relation, PTRTYPE objectfrom, PTRTYPE objectto ) ;
-PTRTYPE lcrnvcreatecollection(PTRTYPE relation ) ;
+LCIO_DEPRECATED_CAPI int lcrnvgaddrelation(PTRTYPE relation, PTRTYPE objectfrom, PTRTYPE objectto, float weight ) ;
+LCIO_DEPRECATED_CAPI int lcrnvgremoverelation(PTRTYPE relation, PTRTYPE objectfrom, PTRTYPE objectto ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcrnvcreatecollection(PTRTYPE relation ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcsch.h
+++ b/src/cpp/include/CPPFORT/lcsch.h
@@ -7,30 +7,32 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcschcreate() ;
-int lcschdelete( PTRTYPE simcalhit ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcschcreate() ;
+LCIO_DEPRECATED_CAPI int lcschdelete( PTRTYPE simcalhit ) ;
 
-int lcschid( PTRTYPE simcalhit ) ;
-int lcschgetcellid0( PTRTYPE simcalhit )  ;
-int lcschgetcellid1( PTRTYPE simcalhit )  ;
-float lcschgetenergy( PTRTYPE simcalhit )  ;
-int lcschgetposition( PTRTYPE simcalhit, float * )  ;
-int lcschgetnmcparticles( PTRTYPE simcalhit )  ;
-int lcschgetnmccontributions( PTRTYPE simcalhit )  ;
+LCIO_DEPRECATED_CAPI int lcschid( PTRTYPE simcalhit ) ;
+LCIO_DEPRECATED_CAPI int lcschgetcellid0( PTRTYPE simcalhit )  ;
+LCIO_DEPRECATED_CAPI int lcschgetcellid1( PTRTYPE simcalhit )  ;
+LCIO_DEPRECATED_CAPI float lcschgetenergy( PTRTYPE simcalhit )  ;
+LCIO_DEPRECATED_CAPI int lcschgetposition( PTRTYPE simcalhit, float * )  ;
+LCIO_DEPRECATED_CAPI int lcschgetnmcparticles( PTRTYPE simcalhit )  ;
+LCIO_DEPRECATED_CAPI int lcschgetnmccontributions( PTRTYPE simcalhit )  ;
 
-PTRTYPE lcschgetparticlecont( PTRTYPE simcalhit, int i)  ;
-float lcschgetenergycont( PTRTYPE simcalhit, int i)  ;
-float lcschgettimecont( PTRTYPE simcalhit, int i)  ;
-int lcschgetpdgcont( PTRTYPE simcalhit, int i)  ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcschgetparticlecont( PTRTYPE simcalhit, int i)  ;
+LCIO_DEPRECATED_CAPI float lcschgetenergycont( PTRTYPE simcalhit, int i)  ;
+LCIO_DEPRECATED_CAPI float lcschgettimecont( PTRTYPE simcalhit, int i)  ;
+LCIO_DEPRECATED_CAPI int lcschgetpdgcont( PTRTYPE simcalhit, int i)  ;
 
-int lcschsetcellid0( PTRTYPE simcalhit, int id0) ;
-int lcschsetcellid1( PTRTYPE simcalhit, int id1) ;
-int lcschsetenergy( PTRTYPE simcalhit, float en) ;
-int lcschsetposition( PTRTYPE simcalhit, float pos[3])  ;
-int lcschaddmcparticlecontribution(  PTRTYPE simcalhit, PTRTYPE mcparticle, float en,float t, int pdg ) ; 
+LCIO_DEPRECATED_CAPI int lcschsetcellid0( PTRTYPE simcalhit, int id0) ;
+LCIO_DEPRECATED_CAPI int lcschsetcellid1( PTRTYPE simcalhit, int id1) ;
+LCIO_DEPRECATED_CAPI int lcschsetenergy( PTRTYPE simcalhit, float en) ;
+LCIO_DEPRECATED_CAPI int lcschsetposition( PTRTYPE simcalhit, float pos[3])  ;
+LCIO_DEPRECATED_CAPI int lcschaddmcparticlecontribution(  PTRTYPE simcalhit, PTRTYPE mcparticle, float en,float t, int pdg ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcsth.h
+++ b/src/cpp/include/CPPFORT/lcsth.h
@@ -6,36 +6,38 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcsthcreate() ;
-int lcsthdelete( PTRTYPE hit ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcsthcreate() ;
+LCIO_DEPRECATED_CAPI int lcsthdelete( PTRTYPE hit ) ;
 
-int lcsthgetcellid( PTRTYPE hit )  ;
-int lcsthgetcellid0( PTRTYPE hit )  ;
-int lcsthgetcellid1( PTRTYPE hit )  ;
-double lcsthgetposition( PTRTYPE hit, int index )  ;
-float lcsthgetmomentum( PTRTYPE hit, int index )  ;
-float lcsthgetpathlength ( PTRTYPE hit )  ;
-float lcsthgetdedx( PTRTYPE hit )  ;
-float lcsthgetedep( PTRTYPE hit ) ;
-float lcsthgettime( PTRTYPE hit )  ;
-int lcsthgetquality( PTRTYPE hit ) ;
+LCIO_DEPRECATED_CAPI int lcsthgetcellid( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI int lcsthgetcellid0( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI int lcsthgetcellid1( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI double lcsthgetposition( PTRTYPE hit, int index )  ;
+LCIO_DEPRECATED_CAPI float lcsthgetmomentum( PTRTYPE hit, int index )  ;
+LCIO_DEPRECATED_CAPI float lcsthgetpathlength ( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI float lcsthgetdedx( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI float lcsthgetedep( PTRTYPE hit ) ;
+LCIO_DEPRECATED_CAPI float lcsthgettime( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI int lcsthgetquality( PTRTYPE hit ) ;
 
-PTRTYPE lcsthgetmcparticle( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcsthgetmcparticle( PTRTYPE hit )  ;
 
-int lcsthsetcellid0( PTRTYPE hit, int id ) ;
-int lcsthsetcellid1( PTRTYPE hit, int id ) ;
-int lcsthsetposition( PTRTYPE hit, double pos[3] )  ;
-int lcsthsetmomentum( PTRTYPE hit, float pos[3] )  ;
-int lcsthsetmomentumxyz( PTRTYPE hit, float px, float py, float pz ) ;
-int lcsthsetpathlength( PTRTYPE hit, float pathLength ) ;
-int lcsthsetdedx( PTRTYPE hit, float dEdX )  ;
-int lcsthsetedep( PTRTYPE hit, float e ) ;
-int lcsthsettime( PTRTYPE hit, float t )  ;
-int lcsthsetmcparticle( PTRTYPE hit,  PTRTYPE  particle )  ;
-int lcsthsetquality( PTRTYPE hit, int quality ) ;
+LCIO_DEPRECATED_CAPI int lcsthsetcellid0( PTRTYPE hit, int id ) ;
+LCIO_DEPRECATED_CAPI int lcsthsetcellid1( PTRTYPE hit, int id ) ;
+LCIO_DEPRECATED_CAPI int lcsthsetposition( PTRTYPE hit, double pos[3] )  ;
+LCIO_DEPRECATED_CAPI int lcsthsetmomentum( PTRTYPE hit, float pos[3] )  ;
+LCIO_DEPRECATED_CAPI int lcsthsetmomentumxyz( PTRTYPE hit, float px, float py, float pz ) ;
+LCIO_DEPRECATED_CAPI int lcsthsetpathlength( PTRTYPE hit, float pathLength ) ;
+LCIO_DEPRECATED_CAPI int lcsthsetdedx( PTRTYPE hit, float dEdX )  ;
+LCIO_DEPRECATED_CAPI int lcsthsetedep( PTRTYPE hit, float e ) ;
+LCIO_DEPRECATED_CAPI int lcsthsettime( PTRTYPE hit, float t )  ;
+LCIO_DEPRECATED_CAPI int lcsthsetmcparticle( PTRTYPE hit,  PTRTYPE  particle )  ;
+LCIO_DEPRECATED_CAPI int lcsthsetquality( PTRTYPE hit, int quality ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcsth.h
+++ b/src/cpp/include/CPPFORT/lcsth.h
@@ -25,7 +25,6 @@ int lcsthgetquality( PTRTYPE hit ) ;
 
 PTRTYPE lcsthgetmcparticle( PTRTYPE hit )  ;
 
-int lcsthsetcellid( PTRTYPE hit, int id ) ;
 int lcsthsetcellid0( PTRTYPE hit, int id ) ;
 int lcsthsetcellid1( PTRTYPE hit, int id ) ;
 int lcsthsetposition( PTRTYPE hit, double pos[3] )  ;
@@ -57,8 +56,7 @@ FCALLSCFUN1(INT, lcsthgetquality,LCSTHGETQUALITY,lcsthgetquality,CFORTRANPNTR)
 
 FCALLSCFUN1(CFORTRANPNTR,lcsthgetmcparticle,LCSTHGETMCPARTICLE,lcsthgetmcparticle,CFORTRANPNTR) 
 
-FCALLSCFUN2(INT, lcsthsetcellid, LCSTHSETCELLID, lcsthsetcellid, CFORTRANPNTR, INT ) 
-FCALLSCFUN2(INT, lcsthsetcellid0, LCSTHSETCELLID0, lcsthsetcellid0, CFORTRANPNTR, INT ) 
+FCALLSCFUN2(INT, lcsthsetcellid0, LCSTHSETCELLID0, lcsthsetcellid0, CFORTRANPNTR, INT )
 FCALLSCFUN2(INT, lcsthsetcellid1, LCSTHSETCELLID1, lcsthsetcellid1, CFORTRANPNTR, INT ) 
 FCALLSCFUN2(INT, lcsthsetposition, LCSTHSETPOSITION, lcsthsetposition, CFORTRANPNTR, DOUBLEV ) 
 FCALLSCFUN2(INT, lcsthsetmomentum, LCSTHSETMOMENTUM, lcsthsetmomentum, CFORTRANPNTR, FLOATV ) 

--- a/src/cpp/include/CPPFORT/lctph.h
+++ b/src/cpp/include/CPPFORT/lctph.h
@@ -6,26 +6,28 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lctphcreate() ;
-int lctphdelete( PTRTYPE hit ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lctphcreate() ;
+LCIO_DEPRECATED_CAPI int lctphdelete( PTRTYPE hit ) ;
 
-int lctphid( PTRTYPE hit )  ;
-int lctphgetcellid( PTRTYPE hit )  ;
-float lctphgettime( PTRTYPE hit )  ;
-float lctphgcharge( PTRTYPE hit )  ;
-int lctphgetquality( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI int lctphid( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI int lctphgetcellid( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI float lctphgettime( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI float lctphgcharge( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI int lctphgetquality( PTRTYPE hit )  ;
 
-int lctphgetnrawdatawords( PTRTYPE hit )  ;
-int lctphgetrawdataword( PTRTYPE hit, int i)  ;
+LCIO_DEPRECATED_CAPI int lctphgetnrawdatawords( PTRTYPE hit )  ;
+LCIO_DEPRECATED_CAPI int lctphgetrawdataword( PTRTYPE hit, int i)  ;
 
-int lctphsetcellid( PTRTYPE hit, int id ) ;
-int lctphsettime( PTRTYPE hit, float t );
-int lctphsetcharge( PTRTYPE hit, float c );
-int lctphsetquality( PTRTYPE hit, int q );
-int lctphsetrawdata( PTRTYPE hit, int* rawData, int size ) ;
+LCIO_DEPRECATED_CAPI int lctphsetcellid( PTRTYPE hit, int id ) ;
+LCIO_DEPRECATED_CAPI int lctphsettime( PTRTYPE hit, float t );
+LCIO_DEPRECATED_CAPI int lctphsetcharge( PTRTYPE hit, float c );
+LCIO_DEPRECATED_CAPI int lctphsetquality( PTRTYPE hit, int q );
+LCIO_DEPRECATED_CAPI int lctphsetrawdata( PTRTYPE hit, int* rawData, int size ) ;
 //int lctphinitrawdataarray( PTRTYPE hit, int size ) ;
 
 // now the fortran wrappers from cfortran.h

--- a/src/cpp/include/CPPFORT/lctrh.h
+++ b/src/cpp/include/CPPFORT/lctrh.h
@@ -6,38 +6,40 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lctrhcreate() ;
-int     lctrhdelete( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lctrhcreate() ;
+LCIO_DEPRECATED_CAPI int     lctrhdelete( PTRTYPE trh ) ;
 
-int     lctrhid( PTRTYPE trh ) ;
-int     lctrhgetposition( PTRTYPE trh, double* pos ) ;
-int     lctrhgetcovmatrix( PTRTYPE trh, float* cvmtx ) ;
-float   lctrhgetdedx( PTRTYPE trh ) ;
-float   lctrhgetedep( PTRTYPE trh ) ;
-float   lctrhgetedeperr( PTRTYPE trh ) ;
-float   lctrhgettime( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI int     lctrhid( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI int     lctrhgetposition( PTRTYPE trh, double* pos ) ;
+LCIO_DEPRECATED_CAPI int     lctrhgetcovmatrix( PTRTYPE trh, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI float   lctrhgetdedx( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI float   lctrhgetedep( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI float   lctrhgetedeperr( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI float   lctrhgettime( PTRTYPE trh ) ;
 //char*   lctrhgettype( PTRTYPE trh ) ;
-int   lctrhgettype( PTRTYPE trh ) ;
-int     lctrhgetquality( PTRTYPE trh )  ;
-int lctrhgetcellid0( PTRTYPE trh )  ;
-int lctrhgetcellid1( PTRTYPE trh )  ;
+LCIO_DEPRECATED_CAPI int   lctrhgettype( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI int     lctrhgetquality( PTRTYPE trh )  ;
+LCIO_DEPRECATED_CAPI int lctrhgetcellid0( PTRTYPE trh )  ;
+LCIO_DEPRECATED_CAPI int lctrhgetcellid1( PTRTYPE trh )  ;
 
-PTRTYPE lctrhgetrawhits( PTRTYPE trh ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lctrhgetrawhits( PTRTYPE trh ) ;
 
-int     lctrhsetposition( PTRTYPE trh, double* pos ) ;
-int     lctrhsetcovmatrix( PTRTYPE trh, float* cvmtx ) ;
-int     lctrhsetdedx( PTRTYPE trh, float dedx ) ;
-int     lctrhsetedep( PTRTYPE trh, float e ) ;
-int     lctrhsetedeperr( PTRTYPE trh, float e ) ;
-int     lctrhsettime( PTRTYPE trh, float time ) ;
-int     lctrhsettype( PTRTYPE trh, int type ) ;
-int     lctrhsetquality( PTRTYPE trh, int q );
-int     lctrhsetcellid0( PTRTYPE trh, int id0) ;
-int     lctrhsetcellid1( PTRTYPE trh, int id1) ;
-int     lctrhaddrawhit( PTRTYPE trh, PTRTYPE rawhit ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsetposition( PTRTYPE trh, double* pos ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsetcovmatrix( PTRTYPE trh, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsetdedx( PTRTYPE trh, float dedx ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsetedep( PTRTYPE trh, float e ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsetedeperr( PTRTYPE trh, float e ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsettime( PTRTYPE trh, float time ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsettype( PTRTYPE trh, int type ) ;
+LCIO_DEPRECATED_CAPI int     lctrhsetquality( PTRTYPE trh, int q );
+LCIO_DEPRECATED_CAPI int     lctrhsetcellid0( PTRTYPE trh, int id0) ;
+LCIO_DEPRECATED_CAPI int     lctrhsetcellid1( PTRTYPE trh, int id1) ;
+LCIO_DEPRECATED_CAPI int     lctrhaddrawhit( PTRTYPE trh, PTRTYPE rawhit ) ;
 
 
 // now the fortran wrappers from cfortran.h              

--- a/src/cpp/include/CPPFORT/lctrk.h
+++ b/src/cpp/include/CPPFORT/lctrk.h
@@ -6,54 +6,56 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lctrkcreate() ;
-int     lctrkdelete( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lctrkcreate() ;
+LCIO_DEPRECATED_CAPI int     lctrkdelete( PTRTYPE trk ) ;
 
-int     lctrkid( PTRTYPE trk ) ;
-int     lctrkgettype( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI int     lctrkid( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI int     lctrkgettype( PTRTYPE trk ) ;
 // int     lctrktesttype( PTRTYPE trk , int bit ) ;
 
-float   lctrkgetd0( PTRTYPE trk ) ;
-float   lctrkgetphi( PTRTYPE trk ) ;
-float   lctrkgetomega( PTRTYPE trk ) ;
-float   lctrkgetz0( PTRTYPE trk ) ;
-float   lctrkgettanlambda( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetd0( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetphi( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetomega( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetz0( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgettanlambda( PTRTYPE trk ) ;
 
-int     lctrkgetcovmatrix( PTRTYPE trk, float* cvmtx ) ;
-int     lctrkgetreferencepoint( PTRTYPE trk, float* refpoint ) ;
+LCIO_DEPRECATED_CAPI int     lctrkgetcovmatrix( PTRTYPE trk, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI int     lctrkgetreferencepoint( PTRTYPE trk, float* refpoint ) ;
 //int     lctrkisreferencepointpca( PTRTYPE trk ) ;
-float   lctrkgetchi2( PTRTYPE trk ) ;
-int     lctrkgetndf( PTRTYPE trk ) ;
-float   lctrkgetdedx( PTRTYPE trk ) ;
-float   lctrkgetdedxerror( PTRTYPE trk ) ;
-float   lctrkgetradiusofinnermosthit(  PTRTYPE trk ) ;
-int     lctrkgetsubdetectorhitnumbers( PTRTYPE trk, int* intv, int* nintv) ;
-PTRTYPE lctrkgettracks( PTRTYPE trk ) ;
-PTRTYPE lctrkgettrackerhits( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetchi2( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI int     lctrkgetndf( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetdedx( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetdedxerror( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI float   lctrkgetradiusofinnermosthit(  PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI int     lctrkgetsubdetectorhitnumbers( PTRTYPE trk, int* intv, int* nintv) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lctrkgettracks( PTRTYPE trk ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lctrkgettrackerhits( PTRTYPE trk ) ;
 
-int     lctrksettypebit( PTRTYPE trk, int index, int val ) ;
-int     lctrksetomega( PTRTYPE trk, float omega ) ;
-int     lctrksettanlambda( PTRTYPE trk, float tanlambda ) ;
-int     lctrksetphi( PTRTYPE trk, float phi ) ;
-int     lctrksetd0( PTRTYPE trk, float d0 ) ;
-int     lctrksetz0( PTRTYPE trk, float z0 ) ;
-int     lctrksetcovmatrix( PTRTYPE trk, float* cvmtx ) ;
-int     lctrksetreferencepoint( PTRTYPE trk, float* refpoint ) ;
+LCIO_DEPRECATED_CAPI int     lctrksettypebit( PTRTYPE trk, int index, int val ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetomega( PTRTYPE trk, float omega ) ;
+LCIO_DEPRECATED_CAPI int     lctrksettanlambda( PTRTYPE trk, float tanlambda ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetphi( PTRTYPE trk, float phi ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetd0( PTRTYPE trk, float d0 ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetz0( PTRTYPE trk, float z0 ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetcovmatrix( PTRTYPE trk, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetreferencepoint( PTRTYPE trk, float* refpoint ) ;
 //int     lctrksetisreferencepointpca( PTRTYPE trk , int val) ;
-int     lctrksetchi2( PTRTYPE trk, float chi2 ) ;
-int     lctrksetndf( PTRTYPE trk, int ndf ) ;
-int     lctrksetdedx( PTRTYPE trk, float dedx ) ;
-int     lctrksetdedxerror( PTRTYPE trk, float dedxerr ) ;
-int     lctrksetradiusofinnermosthit(  PTRTYPE trk , float r) ;
-int     lctrkaddtrack( PTRTYPE trk, PTRTYPE track ) ;
-int     lctrkaddhit( PTRTYPE trk, PTRTYPE hit ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetchi2( PTRTYPE trk, float chi2 ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetndf( PTRTYPE trk, int ndf ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetdedx( PTRTYPE trk, float dedx ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetdedxerror( PTRTYPE trk, float dedxerr ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetradiusofinnermosthit(  PTRTYPE trk , float r) ;
+LCIO_DEPRECATED_CAPI int     lctrkaddtrack( PTRTYPE trk, PTRTYPE track ) ;
+LCIO_DEPRECATED_CAPI int     lctrkaddhit( PTRTYPE trk, PTRTYPE hit ) ;
 
 // fg: this method has no direct correspondence in the C++ API as there the vector is manipulated
 // directly through it's interface via getSubdetectorHitNumbers
-int     lctrksetsubdetectorhitnumbers( PTRTYPE trk, int* intv, const int nintv ) ;
+LCIO_DEPRECATED_CAPI int     lctrksetsubdetectorhitnumbers( PTRTYPE trk, int* intv, const int nintv ) ;
                                                  
 
 // now the fortran wrappers from cfortran.h              

--- a/src/cpp/include/CPPFORT/lcvec.h
+++ b/src/cpp/include/CPPFORT/lcvec.h
@@ -4,8 +4,11 @@
  * @version Nov 3, 2003
  */
 
+
 #include "cfortran.h"
 #include "cpointer.h"
+
+#include "deprecation.h"
 
 #include <string>
 #include <vector>
@@ -16,27 +19,27 @@ typedef std::vector<PTRTYPE> PointerVec ;
 
 
 // define an interface to a LC string/int/float vector
-int   lcsvcgetlength(PTRTYPE strvec) ;
-char* lcsvcgetstringat(PTRTYPE strvec, int index) ;
+LCIO_DEPRECATED_CAPI int   lcsvcgetlength(PTRTYPE strvec) ;
+LCIO_DEPRECATED_CAPI char* lcsvcgetstringat(PTRTYPE strvec, int index) ;
 
-int   lcivcgetlength(PTRTYPE intvec) ;
-int   lcivcgetintat(PTRTYPE intvec, int index) ;
+LCIO_DEPRECATED_CAPI int   lcivcgetlength(PTRTYPE intvec) ;
+LCIO_DEPRECATED_CAPI int   lcivcgetintat(PTRTYPE intvec, int index) ;
 
-int   lcfvcgetlength(PTRTYPE floatvec) ;
-float lcfvcgetfloatat(PTRTYPE floatvec, int index) ;
+LCIO_DEPRECATED_CAPI int   lcfvcgetlength(PTRTYPE floatvec) ;
+LCIO_DEPRECATED_CAPI float lcfvcgetfloatat(PTRTYPE floatvec, int index) ;
 
 // define an interface to read a standard string/int/pointer/float vector
-int   stringvectorgetlength(PTRTYPE strvec) ;
-char* stringvectorgetelement(PTRTYPE strvec, int index) ;
+LCIO_DEPRECATED_CAPI int   stringvectorgetlength(PTRTYPE strvec) ;
+LCIO_DEPRECATED_CAPI char* stringvectorgetelement(PTRTYPE strvec, int index) ;
 
-int   intvectorgetlength(PTRTYPE intvec) ;
-int   intvectorgetelement(PTRTYPE intvec, int index) ;
+LCIO_DEPRECATED_CAPI int   intvectorgetlength(PTRTYPE intvec) ;
+LCIO_DEPRECATED_CAPI int   intvectorgetelement(PTRTYPE intvec, int index) ;
 
-int     pointervectorgetlength(PTRTYPE intvec) ;
-PTRTYPE pointervectorgetelement(PTRTYPE intvec, int index) ;
+LCIO_DEPRECATED_CAPI int     pointervectorgetlength(PTRTYPE intvec) ;
+LCIO_DEPRECATED_CAPI PTRTYPE pointervectorgetelement(PTRTYPE intvec, int index) ;
 
-int   floatvectorgetlength(PTRTYPE floatvec) ;
-float floatvectorgetelement(PTRTYPE floatvec, int index) ;
+LCIO_DEPRECATED_CAPI int   floatvectorgetlength(PTRTYPE floatvec) ;
+LCIO_DEPRECATED_CAPI float floatvectorgetelement(PTRTYPE floatvec, int index) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcvtx.h
+++ b/src/cpp/include/CPPFORT/lcvtx.h
@@ -6,31 +6,32 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcvtxcreate() ;
-int     lcvtxdelete( PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcvtxcreate() ;
+LCIO_DEPRECATED_CAPI int     lcvtxdelete( PTRTYPE vtx ) ;
 
-int     lcvtxid( PTRTYPE vtx ) ;
-bool    lcvtxisprimary( PTRTYPE vtx ) ;
-char*   lcvtxgetalgorithmtype( PTRTYPE vtx ) ;
-float   lcvtxgetchi2( PTRTYPE vtx ) ;
-float   lcvtxgetprobability( PTRTYPE vtx ) ;
-int     lcvtxgetposition( PTRTYPE vtx, float* pos ) ;
-int     lcvtxgetcovmatrix( PTRTYPE vtx, float* cvmtx ) ;
-int     lcvtxgetparameters( PTRTYPE vtx, float* vec, int* nvec ) ;
-PTRTYPE lcvtxgetassociatedparticle( PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxid( PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI bool    lcvtxisprimary( PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI char*   lcvtxgetalgorithmtype( PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI float   lcvtxgetchi2( PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI float   lcvtxgetprobability( PTRTYPE vtx ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxgetposition( PTRTYPE vtx, float* pos ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxgetcovmatrix( PTRTYPE vtx, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxgetparameters( PTRTYPE vtx, float* vec, int* nvec ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcvtxgetassociatedparticle( PTRTYPE vtx ) ;
 
-int     lcvtxsetprimary( PTRTYPE vtx, bool pri ) ;
-int     lcvtxsetalgorithmtype( PTRTYPE vtx, char* type ) ;
-int     lcvtxsetchi2( PTRTYPE vtx, float chi2 ) ;
-int     lcvtxsetprobability( PTRTYPE vtx, float prob ) ;
-int     lcvtxsetposition( PTRTYPE vtx, float* pos ) ;
-int     lcvtxsetcovmatrix( PTRTYPE vtx, float* cvmtx ) ;
-int     lcvtxaddparameter( PTRTYPE vtx, float param ) ;
-int     lcvtxsetassociatedparticle( PTRTYPE vtx, PTRTYPE rcp ) ;
-
+LCIO_DEPRECATED_CAPI int     lcvtxsetprimary( PTRTYPE vtx, bool pri ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxsetalgorithmtype( PTRTYPE vtx, char* type ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxsetchi2( PTRTYPE vtx, float chi2 ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxsetprobability( PTRTYPE vtx, float prob ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxsetposition( PTRTYPE vtx, float* pos ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxsetcovmatrix( PTRTYPE vtx, float* cvmtx ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxaddparameter( PTRTYPE vtx, float param ) ;
+LCIO_DEPRECATED_CAPI int     lcvtxsetassociatedparticle( PTRTYPE vtx, PTRTYPE rcp ) ;
 
 // now the fortran wrappers from cfortran.h
 extern "C"{

--- a/src/cpp/include/CPPFORT/lcwrt.h
+++ b/src/cpp/include/CPPFORT/lcwrt.h
@@ -7,18 +7,20 @@
 #include "cfortran.h"
 #include "cpointer.h"
 
+#include "deprecation.h"
+
 // Warning: dont use "_" in function names as this causes two many
 // trailing underscores on Linux
 
-PTRTYPE lcwrtcreate() ;
-int     lcwrtdelete( PTRTYPE writer ) ;
+LCIO_DEPRECATED_CAPI PTRTYPE lcwrtcreate() ;
+LCIO_DEPRECATED_CAPI int     lcwrtdelete( PTRTYPE writer ) ;
 
 // the writer interface
-int   lcwrtopen( PTRTYPE writer, const char* filename , int writeMode ) ;
-int   lcwrtclose( PTRTYPE writer ) ;
+LCIO_DEPRECATED_CAPI int   lcwrtopen( PTRTYPE writer, const char* filename , int writeMode ) ;
+LCIO_DEPRECATED_CAPI int   lcwrtclose( PTRTYPE writer ) ;
 
-int   lcwrtwriterunheader( PTRTYPE writer, PTRTYPE header) ;
-int   lcwrtwriteevent( PTRTYPE writer, PTRTYPE event) ;
+LCIO_DEPRECATED_CAPI int   lcwrtwriterunheader( PTRTYPE writer, PTRTYPE header) ;
+LCIO_DEPRECATED_CAPI int   lcwrtwriteevent( PTRTYPE writer, PTRTYPE event) ;
 
 
 // now the fortran wrappers from cfortran.h

--- a/src/f77/CMakeLists.txt
+++ b/src/f77/CMakeLists.txt
@@ -21,6 +21,11 @@ IF( CMAKE_COMPILER_IS_GNUCC )
         MESSAGE( STATUS "adding -fno-range-check fortran compiler flag" )
         SET( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-range-check" )
     ENDIF()
+    IF ( ${GCC_VERSION} VERSION_GREATER 10 )
+      # fix the BOZ literal constant errors that are treated more stringent
+      # starting from gcc10 (turns the errors into warnings)
+      SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz")
+    ENDIF()
 ENDIF()
 
 

--- a/src/f77/lciof77api.inc
+++ b/src/f77/lciof77api.inc
@@ -128,12 +128,12 @@ c-----the MCParticle interface
 
 c-----the SimTrackerHit interface
       PTRTYPE lcsthcreate, lcsthgetmcparticle
-      integer lcsthdelete, lcsthgetcellid
+      integer lcsthdelete, lcsthgetcellid, lcsthgetcellid0, lcsthgetcellid1
       real    lcsthgetdedx, lcsthgetedep, lcsthgettime
       double precision lcsthgetposition
       real lcsthgetmomentum, lcsthgetpathlength
-      integer lcsthsetcellid, lcsthsetposition, lcsthsetdedx
-      integer lcsthsetedep
+      integer lcsthsetcellid0, lcsthsetcellid1, lcsthsetposition
+      integer lcsthsetedep, lcsthsetdedx
       integer lcsthsettime, lcsthsetmcparticle, lcsthsetmomentum
       integer lcsthsetmomentumxyz, lcsthsetpathlength
 

--- a/src/f77/simjob.F
+++ b/src/f77/simjob.F
@@ -314,7 +314,7 @@ c--------     test new relation navigator object
               status     = lctphsetcellid( tpcHit, j-1 )
               status     = lctphsettime( tpcHit, 0.1234567 )
               status     = lctphsetcharge( tpcHit, 3.14159 )
-              status     = lctphsetquality( tpcHit, z'bad' )
+              status     = lctphsetquality( tpcHit, int(z'bad') )
               if (storeRawData)  then
                 size       = ( dble(irand( 0 ) )/RAND_MAX )*10
                 do  k = 1,size

--- a/src/f77/simjob_chain.F
+++ b/src/f77/simjob_chain.F
@@ -196,7 +196,7 @@ c--------   set the flag bits to store position and pdg for simulated calorimete
             do k=1,nhit
 
                hit = lcsthcreate() 
-               status = lcsthsetcellid( hit,  314159 ) 
+               status = lcsthsetcellid0( hit,  314159 )
                sthpos(1) = 1.
                sthpos(2) = 2.
                sthpos(3) = 3.

--- a/src/f77/simjob_chain.F
+++ b/src/f77/simjob_chain.F
@@ -190,7 +190,7 @@ c-------- create some monte carlo particles
 c------   simulated tracker hits
 
 c--------   set the flag bits to store position and pdg for simulated calorimeter hits
-            flag = 2**31 + 2**28
+            flag = (-2)**31 + 2**28
             status = lccolsetflag( schcol, flag )
 
             do k=1,nhit
@@ -239,7 +239,7 @@ c ---            add energy from 2 MCParticles to each hit
 c---- real data calorimeter hits
 
 c ----      set the flag bits to store position for calorimeter hits
-            flag = 2**31
+            flag = (-2)**31
             status = lccolsetflag( cahcol, flag )
 
             do k=1,nhit


### PR DESCRIPTION
BEGINRELEASENOTES
- Deprecate the C-API which is used by the fortran interface. However, since no one seems to be actively using that interface we introduce a deprecation warning for the C-API to see if that has any users outside of the internal fortran interface. **If you are seeing deprecation messages in your build outputs please let us know.**
- Fix F77 tests and run them in the CI.
  - Degrade some compiler errors back to warnings for gcc10 as it has become more strict than previous versions.

ENDRELEASENOTES

The `SimTrackerHitImpl::setCellID` function does not exist in cpp, so it probably shouldn't exist for the fortran API either. Also added the non-deprecated `lcsthgetcellid0` and `lcsthgetcellid1` to the API (implementations were already present).