### PR TITLE
add double values to LCParameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ include(GNUInstallDirs)
 
 # project version
 SET( LCIO_VERSION_MAJOR 2 )
-SET( LCIO_VERSION_MINOR 16 )
-SET( LCIO_VERSION_PATCH 1 )
+SET( LCIO_VERSION_MINOR 17 )
+SET( LCIO_VERSION_PATCH 0 )
 
 ### set correct LCIO version in relevant files  ############################
 

--- a/src/aid/EVENT/LCParameters.aid
+++ b/src/aid/EVENT/LCParameters.aid
@@ -90,6 +90,11 @@ public interface LCParameters
 
     /** Returns values for the given key.
      */
+    public DoubleVec& getDoubleVals( const String& key ) const;
+
+
+    /** Returns values for the given key.
+     */
     public StringVec& getStringVals( const String& key  ) const;
 
     /** Returns a list of all keys of integer parameters.

--- a/src/aid/EVENT/LCParameters.aid
+++ b/src/aid/EVENT/LCParameters.aid
@@ -30,6 +30,11 @@ public interface LCParameters
     public float getFloatVal( const String& key )const ;
 
 
+    /** Returns the first double value for the given key.
+     */
+    public double getDoubleVal( const String& key )const ;
+
+
     /** Returns the first string value for the given key.
      */
     public const String& getStringVal( const String& key ) const ;
@@ -46,6 +51,11 @@ public interface LCParameters
      */
     public FloatVec& getFloatVals( const String& key ,  FloatVec& values ) const ;
 
+    /** Adds all double values for the given key to values.
+     *  Returns a reference to values for convenience.
+     */
+    public DoubleVec& getDoubleVals( const String& key ,  DoubleVec& values ) const ;
+
 
     /** Adds all string values for the given key to values.
      *  Returns a reference to values for convenience.
@@ -59,6 +69,10 @@ public interface LCParameters
     /** Returns a list of all keys of float parameters.
      */
     public const StringVec& getFloatKeys( StringVec &keys ) const ;
+
+    /** Returns a list of all keys of double parameters.
+     */
+    public const StringVec& getDoubleKeys( StringVec &keys ) const ;
 
     /** Returns a list of all keys of string parameters.
      */
@@ -100,6 +114,10 @@ public interface LCParameters
      */ 
     public int getNFloat( const String& key ) const ;
 
+    /** The number of double values stored for this key.
+     */ 
+    public int getNDouble( const String& key ) const ;
+
     /** The number of string values stored for this key.
      */ 
     public int getNString( const String& key ) const ;
@@ -112,6 +130,10 @@ public interface LCParameters
      */
     public void setValue(const String & key, float  value);
 
+    /** Set double value for the given key.
+     */
+    public void setValue(const String & key, double  value);
+
     /** Set string value for the given key.
      */
     public void setValue(const String & key, const String & value);
@@ -123,6 +145,10 @@ public interface LCParameters
     /** Set float values for the given key.
      */
     public void setValues(const String & key, const FloatVec & values);
+
+    /** Set double values for the given key.
+     */
+    public void setValues(const String & key, const DoubleVec & values);
 
     /** Set string values for the given key.
      */

--- a/src/aid/EVENT/LCParameters.aid
+++ b/src/aid/EVENT/LCParameters.aid
@@ -47,7 +47,7 @@ public interface LCParameters
     public FloatVec& getFloatVals( const String& key ,  FloatVec& values ) const ;
 
 
-    /** Adds all float values for the given key to values.
+    /** Adds all string values for the given key to values.
      *  Returns a reference to values for convenience.
      */
     public StringVec& getStringVals( const String& key  , StringVec & values ) const ;

--- a/src/aid/EVENT/Vertex.aid
+++ b/src/aid/EVENT/Vertex.aid
@@ -24,7 +24,7 @@ public interface Vertex extends LCObject {
 @ifdef cpp
 @cpp{
    Vertex() = default ;
-   Vertex(Const Vertex&) = default ;
+   Vertex(const Vertex&) = default ;
 }
 @cpp{
     /** Useful typedef for template programming with LCIO */

--- a/src/cpp/include/IMPL/LCParametersImpl.h
+++ b/src/cpp/include/IMPL/LCParametersImpl.h
@@ -17,6 +17,7 @@ namespace IMPL {
 
   typedef std::map< std::string, EVENT::IntVec >    IntMap ;
   typedef std::map< std::string, EVENT::FloatVec >  FloatMap ;
+  typedef std::map< std::string, EVENT::DoubleVec > DoubleMap ;
   typedef std::map< std::string, EVENT::StringVec > StringMap ;
   
 
@@ -53,6 +54,10 @@ namespace IMPL {
      */
     virtual float getFloatVal(const std::string & key) const ;
     
+    /** Returns the first double value for the given key.
+     */
+    virtual double getDoubleVal(const std::string & key) const ;
+
     /** Returns the first string value for the given key.
      */
     virtual const std::string & getStringVal(const std::string & key) const ;
@@ -67,10 +72,15 @@ namespace IMPL {
      */
     virtual EVENT::FloatVec & getFloatVals(const std::string & key, EVENT::FloatVec & values) const ;
     
+    /** Adds all double values for the given key to values.
+     *  Returns a reference to values for convenience.
+     */
+    virtual EVENT::DoubleVec & getDoubleVals(const std::string & key, EVENT::DoubleVec & values) const ;
+
     /** Adds all string values for the given key to values.
      *  Returns a reference to values for convenience.
      */
-    virtual  EVENT::StringVec & getStringVals(const std::string & key, EVENT::StringVec & values) const ;
+    virtual EVENT::StringVec & getStringVals(const std::string & key, EVENT::StringVec & values) const ;
     
     /** Returns a list of all keys of integer parameters.
      */
@@ -79,6 +89,10 @@ namespace IMPL {
     /** Returns a list of all keys of float parameters.
      */
     virtual const EVENT::StringVec & getFloatKeys(EVENT::StringVec & keys)  const ;
+
+    /** Returns a list of all keys of double parameters.
+     */
+    virtual const EVENT::StringVec & getDoubleKeys(EVENT::StringVec & keys) const ;
 
     /** Returns a list of all keys of string parameters.
      */
@@ -92,6 +106,10 @@ namespace IMPL {
      */ 
     virtual int getNFloat(const std::string & key) const ;
     
+    /** The number of double values stored for this key.
+     */ 
+    virtual int getNDouble(const std::string & key) const ;
+
     /** The number of string values stored for this key.
      */ 
     virtual int getNString(const std::string & key) const ;
@@ -103,6 +121,10 @@ namespace IMPL {
     /** Set float value for the given key.
      */
     virtual void setValue(const std::string & key, float value) ;
+
+    /** Set double value for the given key.
+     */
+    virtual void setValue(const std::string & key, double value) ;
 
     /** Set string value for the given key.
      */
@@ -116,6 +138,10 @@ namespace IMPL {
      */
     virtual void setValues(const std::string & key, const EVENT::FloatVec & values);
 
+    /** Set double values for the given key.
+     */
+    virtual void setValues(const std::string & key, const EVENT::DoubleVec & values) ;
+
     /** Set string values for the given key.
      */
     virtual void setValues(const std::string & key, const EVENT::StringVec & values);
@@ -125,6 +151,7 @@ namespace IMPL {
 
     mutable IntMap _intMap{} ;
     mutable FloatMap _floatMap{} ;
+    mutable DoubleMap _doubleMap{} ;
     mutable StringMap _stringMap{} ;
     
   }; // class

--- a/src/cpp/include/IMPL/LCParametersImpl.h
+++ b/src/cpp/include/IMPL/LCParametersImpl.h
@@ -67,7 +67,7 @@ namespace IMPL {
      */
     virtual EVENT::FloatVec & getFloatVals(const std::string & key, EVENT::FloatVec & values) const ;
     
-    /** Adds all float values for the given key to values.
+    /** Adds all string values for the given key to values.
      *  Returns a reference to values for convenience.
      */
     virtual  EVENT::StringVec & getStringVals(const std::string & key, EVENT::StringVec & values) const ;

--- a/src/cpp/include/pre-generated/EVENT/LCParameters.h
+++ b/src/cpp/include/pre-generated/EVENT/LCParameters.h
@@ -53,7 +53,7 @@ public:
      */
     virtual FloatVec & getFloatVals(const std::string & key, FloatVec & values) const = 0;
 
-    /** Adds all float values for the given key to values.
+    /** Adds all string values for the given key to values.
      *  Returns a reference to values for convenience.
      */
     virtual StringVec & getStringVals(const std::string & key, StringVec & values) const = 0;

--- a/src/cpp/include/pre-generated/EVENT/LCParameters.h
+++ b/src/cpp/include/pre-generated/EVENT/LCParameters.h
@@ -39,6 +39,10 @@ public:
      */
     virtual float getFloatVal(const std::string & key) const = 0;
 
+    /** Returns the first double value for the given key.
+     */
+    virtual double getDoubleVal(const std::string & key) const = 0;
+
     /** Returns the first string value for the given key.
      */
     virtual const std::string & getStringVal(const std::string & key) const = 0;
@@ -53,6 +57,11 @@ public:
      */
     virtual FloatVec & getFloatVals(const std::string & key, FloatVec & values) const = 0;
 
+    /** Adds all double values for the given key to values.
+     *  Returns a reference to values for convenience.
+     */
+    virtual DoubleVec & getDoubleVals(const std::string & key, DoubleVec & values) const = 0;
+
     /** Adds all string values for the given key to values.
      *  Returns a reference to values for convenience.
      */
@@ -66,6 +75,10 @@ public:
      */
     virtual const StringVec & getFloatKeys(StringVec & keys) const = 0;
 
+    /** Returns a list of all keys of double parameters.
+     */
+    virtual const StringVec & getDoubleKeys(StringVec & keys) const = 0;
+
     /** Returns a list of all keys of string parameters.
      */
     virtual const StringVec & getStringKeys(StringVec & keys) const = 0;
@@ -77,6 +90,10 @@ public:
     /** The number of float values stored for this key.
      */ 
     virtual int getNFloat(const std::string & key) const = 0;
+
+    /** The number of double values stored for this key.
+     */ 
+    virtual int getNDouble(const std::string & key) const = 0;
 
     /** The number of string values stored for this key.
      */ 
@@ -90,6 +107,10 @@ public:
      */
     virtual void setValue(const std::string & key, float value) = 0;
 
+    /** Set double value for the given key.
+     */
+    virtual void setValue(const std::string & key, double value) = 0;
+
     /** Set string value for the given key.
      */
     virtual void setValue(const std::string & key, const std::string & value) = 0;
@@ -101,6 +122,10 @@ public:
     /** Set float values for the given key.
      */
     virtual void setValues(const std::string & key, const FloatVec & values) = 0;
+
+    /** Set double values for the given key.
+     */
+    virtual void setValues(const std::string & key, const DoubleVec & values) = 0;
 
     /** Set string values for the given key.
      */

--- a/src/cpp/src/EXAMPLE/simjob.cc
+++ b/src/cpp/src/EXAMPLE/simjob.cc
@@ -136,6 +136,13 @@ int main(int argc, char** argv ){
  	fv.push_back( 3.3 ) ;
 	evt->parameters().setValues( "SomeNumbers" , fv ) ; 
 	
+	DoubleVec dv ;
+	dv.push_back( 1.111111111111111111111111111111111111111111111111 ) ;
+	dv.push_back( 2.222222222222222222222222222222222222222222222222 ) ;
+	dv.push_back( 3.333333333333333333333333333333333333333333333333 ) ;
+	evt->parameters().setValues( "SomeDoubleNumbers" , dv ) ;
+
+
 	// create and add some mc particles 
 	LCCollectionVec* mcVec = new LCCollectionVec( LCIO::MCPARTICLE )  ;
 	

--- a/src/cpp/src/IMPL/LCParametersImpl.cc
+++ b/src/cpp/src/IMPL/LCParametersImpl.cc
@@ -33,6 +33,17 @@ namespace IMPL{
     return fv[0] ;
   }
 
+  double LCParametersImpl::getDoubleVal(const std::string & key) const {
+
+    DoubleMap::iterator it = _doubleMap.find( key ) ;
+
+    if( it == _doubleMap.end() )  return 0 ;
+
+    DoubleVec &  fv =  it->second ;
+
+    return fv[0] ;
+  }
+
   const std::string & LCParametersImpl::getStringVal(const std::string & key) const {
 
     static std::string empty("") ;
@@ -62,6 +73,16 @@ namespace IMPL{
     FloatMap::iterator it = _floatMap.find( key ) ;
 
     if( it != _floatMap.end() ) {
+      values.insert( values.end() , it->second.begin() , it->second.end() ) ;
+    }
+    return values ;
+  }
+
+  DoubleVec & LCParametersImpl::getDoubleVals(const std::string & key, DoubleVec & values) const {
+
+    DoubleMap::iterator it = _doubleMap.find( key ) ;
+
+    if( it != _doubleMap.end() ) {
       values.insert( values.end() , it->second.begin() , it->second.end() ) ;
     }
     return values ;
@@ -99,6 +120,16 @@ namespace IMPL{
     return keys ;
   }
 
+  const StringVec & LCParametersImpl::getDoubleKeys(StringVec & keys) const  {
+    
+     for( DoubleMap::iterator iter = _doubleMap.begin() ; iter !=  _doubleMap.end() ; iter++ ){
+       keys.push_back( iter->first ) ; 
+     }
+// fg: select1st is non-standard
+//    transform( _doubleMap.begin() , _doubleMap.end() , back_inserter( keys )  , select1st< DoubleMap::value_type >() ) ;
+    return keys ;
+  }
+
   const StringVec & LCParametersImpl::getStringKeys(StringVec & keys) const  {
 
     for( StringMap::iterator iter = _stringMap.begin() ; iter !=  _stringMap.end() ; iter++ ){
@@ -129,6 +160,16 @@ namespace IMPL{
       return it->second.size() ;
   }
 
+  int LCParametersImpl::getNDouble(const std::string & key) const {
+
+    DoubleMap::iterator it = _doubleMap.find( key ) ;
+
+    if( it == _doubleMap.end() )  
+      return 0 ;
+    else
+      return it->second.size() ;
+  }
+
   int LCParametersImpl::getNString(const std::string & key) const {
 
     StringMap::iterator it = _stringMap.find( key ) ;
@@ -151,6 +192,13 @@ namespace IMPL{
 //     if(  _floatMap[ key ].size() > 0 ) 
     _floatMap[ key ].clear() ;
     _floatMap[ key ].push_back( value ) ;
+  }
+
+  void LCParametersImpl::setValue(const std::string & key, double value){
+    checkAccess("LCParametersImpl::setValue") ;
+//     if(  _doubleMap[ key ].size() > 0 ) 
+    _doubleMap[ key ].clear() ;
+    _doubleMap[ key ].push_back( value ) ;
   }
 
   void LCParametersImpl::setValue(const std::string & key, const std::string & value) {
@@ -181,6 +229,16 @@ namespace IMPL{
 //     copy( values.begin() , values.end() , back_inserter(  _floatMap[ key ] )  ) ;
 
     _floatMap[ key ].assign(  values.begin() , values.end() ) ;
+  }
+  
+  void LCParametersImpl::setValues(const std::string & key,const  EVENT::DoubleVec & values){
+
+    checkAccess("LCParametersImpl::setValues") ;
+
+//     if(  _doubleMap[ key ].size() > 0 ) _doubleMap[ key ].clear() ;
+//     copy( values.begin() , values.end() , back_inserter(  _doubleMap[ key ] )  ) ;
+
+    _doubleMap[ key ].assign(  values.begin() , values.end() ) ;
   }
   
   void LCParametersImpl::setValues(const std::string & key, const EVENT::StringVec & values){

--- a/src/cpp/src/SIO/SIOLCParameters.cc
+++ b/src/cpp/src/SIO/SIOLCParameters.cc
@@ -33,6 +33,19 @@ namespace SIO {
       }
       params.setValues( key , floatVec ) ;
     }
+    int nDoubleParameters ;
+    SIO_DATA( device , &nDoubleParameters , 1 ) ;
+    for(int i=0; i< nDoubleParameters ; i++ ) {
+      std::string key;
+      SIO_SDATA( device,  key ) ;
+      int nDouble  ;
+      SIO_DATA( device , &nDouble , 1 ) ;
+      EVENT::DoubleVec doubleVec(nDouble) ;
+      for(int j=0; j< nDouble ; j++ ) {
+	      SIO_DATA( device , &doubleVec[j]  , 1 ) ;
+      }
+      params.setValues( key , doubleVec ) ;
+    }
     int nStringParameters ;
     SIO_DATA( device , &nStringParameters , 1 ) ;
     for(int i=0; i< nStringParameters ; i++ ) {
@@ -76,6 +89,19 @@ namespace SIO {
     	for(int j=0; j< nFloat ; j++ ){
     	  SIO_SDATA( device, floatVec[j]  ) ;
     	}
+    }
+    EVENT::StringVec doubleKeys ;
+    int nDoubleParameters = params.getDoubleKeys( doubleKeys ).size() ;
+    SIO_DATA( device , &nDoubleParameters , 1 ) ;
+    for(int i=0; i< nDoubleParameters ; i++ ) {
+      EVENT::DoubleVec doubleVec ;
+      params.getDoubleVals(  doubleKeys[i], doubleVec ) ;
+      int nDouble  = doubleVec.size()  ;     // = params.getNDouble( doubleKeys[i] ) ;
+	SIO_SDATA( device, doubleKeys[i]  ) ;
+	SIO_DATA( device , &nDouble , 1 ) ;
+	for(int j=0; j< nDouble ; j++ ){
+	  SIO_SDATA( device, doubleVec[j]  ) ;
+	}
     }
     EVENT::StringVec stringKeys ;
     int nStringParameters = params.getStringKeys( stringKeys ).size() ;

--- a/src/cpp/src/SIO/SIOLCParameters.cc
+++ b/src/cpp/src/SIO/SIOLCParameters.cc
@@ -6,7 +6,7 @@
 
 namespace SIO {
     
-  void SIOLCParameters::read( sio::read_device &device, EVENT::LCParameters& params, sio::version_type /*vers*/ ) {
+  void SIOLCParameters::read( sio::read_device &device, EVENT::LCParameters& params, sio::version_type vers ) {
     int nIntParameters ;
     SIO_DATA( device , &nIntParameters , 1 ) ;
     for(int i=0; i< nIntParameters ; i++ ) {
@@ -33,18 +33,21 @@ namespace SIO {
       }
       params.setValues( key , floatVec ) ;
     }
-    int nDoubleParameters ;
-    SIO_DATA( device , &nDoubleParameters , 1 ) ;
-    for(int i=0; i< nDoubleParameters ; i++ ) {
-      std::string key;
-      SIO_SDATA( device,  key ) ;
-      int nDouble  ;
-      SIO_DATA( device , &nDouble , 1 ) ;
-      EVENT::DoubleVec doubleVec(nDouble) ;
-      for(int j=0; j< nDouble ; j++ ) {
-	      SIO_DATA( device , &doubleVec[j]  , 1 ) ;
+    if( vers > SIO_VERSION_ENCODE( 2, 16 )   ) {
+
+      int nDoubleParameters ;
+      SIO_DATA( device , &nDoubleParameters , 1 ) ;
+      for(int i=0; i< nDoubleParameters ; i++ ) {
+	std::string key;
+	SIO_SDATA( device,  key ) ;
+	int nDouble  ;
+	SIO_DATA( device , &nDouble , 1 ) ;
+	EVENT::DoubleVec doubleVec(nDouble) ;
+	for(int j=0; j< nDouble ; j++ ) {
+	  SIO_DATA( device , &doubleVec[j]  , 1 ) ;
+	}
+	params.setValues( key , doubleVec ) ;
       }
-      params.setValues( key , doubleVec ) ;
     }
     int nStringParameters ;
     SIO_DATA( device , &nStringParameters , 1 ) ;
@@ -97,11 +100,11 @@ namespace SIO {
       EVENT::DoubleVec doubleVec ;
       params.getDoubleVals(  doubleKeys[i], doubleVec ) ;
       int nDouble  = doubleVec.size()  ;     // = params.getNDouble( doubleKeys[i] ) ;
-	SIO_SDATA( device, doubleKeys[i]  ) ;
-	SIO_DATA( device , &nDouble , 1 ) ;
-	for(int j=0; j< nDouble ; j++ ){
-	  SIO_SDATA( device, doubleVec[j]  ) ;
-	}
+      SIO_SDATA( device, doubleKeys[i]  ) ;
+      SIO_DATA( device , &nDouble , 1 ) ;
+      for(int j=0; j< nDouble ; j++ ){
+	SIO_SDATA( device, doubleVec[j]  ) ;
+      }
     }
     EVENT::StringVec stringKeys ;
     int nStringParameters = params.getStringKeys( stringKeys ).size() ;

--- a/src/cpp/src/UTIL/LCTOOLS.cc
+++ b/src/cpp/src/UTIL/LCTOOLS.cc
@@ -1347,6 +1347,21 @@ namespace UTIL {
             }
             cout << endl ;
         }
+        StringVec doubleKeys ;
+        int nDoubleParameters = params.getDoubleKeys( doubleKeys ).size() ;
+        for(int i=0; i< nDoubleParameters ; i++ ){
+            DoubleVec doubleVec ;
+            params.getDoubleVals(  doubleKeys[i], doubleVec ) ;
+            int nDouble  = doubleVec.size()  ;   
+            cout << " parameter " << doubleKeys[i] << " [double]: " ; 
+            if( nDouble == 0 ){ 
+                cout << " [empty] " << std::endl ;
+            }
+            for(int j=0; j< nDouble ; j++ ){
+                cout << doubleVec[j] << ", " ;
+            }
+            cout << endl ;
+        }
         StringVec stringKeys ;
         int nStringParameters = params.getStringKeys( stringKeys ).size() ;
         for(int i=0; i< nStringParameters ; i++ ){

--- a/src/java/hep/lcio/implementation/event/ILCParameters.java
+++ b/src/java/hep/lcio/implementation/event/ILCParameters.java
@@ -13,6 +13,7 @@ public class ILCParameters extends ILCObject implements LCParameters
 {
    protected Map _intMap = new HashMap() ;
    protected Map _floatMap = new HashMap() ;
+   protected Map _doubleMap = new HashMap() ;
    protected Map _stringMap = new HashMap() ;
    
    public int getIntVal(String key)
@@ -28,6 +29,16 @@ public class ILCParameters extends ILCObject implements LCParameters
    {
       
       float[] vals = (float[]) _floatMap.get( key ) ;
+      if(vals==null||vals.length==0)
+         return 0 ;
+      
+      return vals[0] ;
+   }
+   
+   public double getDoubleVal(String key)
+   {
+      
+      double[] vals = (double[]) _doubleMap.get( key ) ;
       if(vals==null||vals.length==0)
          return 0 ;
       
@@ -54,6 +65,11 @@ public class ILCParameters extends ILCObject implements LCParameters
       return (float[]) _floatMap.get(key) ;
    }
    
+   public double[] getDoubleVals(String key)
+   {
+      return (double[]) _doubleMap.get(key) ;
+   }
+   
    public String[] getStringVals(String key)
    {
       return (String[]) _stringMap.get(key) ;
@@ -73,6 +89,17 @@ public class ILCParameters extends ILCObject implements LCParameters
    public String[] getFloatKeys()
    {
       Object[] ob = _floatMap.keySet().toArray() ;
+      String[] keys = new String[ ob.length ] ;
+      for (int i = 0; i < keys.length; i++)
+      {
+         keys[i] = (String) ob[i] ;
+      }
+      return keys  ;
+   }
+   
+   public String[] getDoubleKeys()
+   {
+      Object[] ob = _doubleMap.keySet().toArray() ;
       String[] keys = new String[ ob.length ] ;
       for (int i = 0; i < keys.length; i++)
       {
@@ -106,6 +133,13 @@ public class ILCParameters extends ILCObject implements LCParameters
       return a.length ;
    }
    
+   public int getNDouble(String key)
+   {
+      double[] a = (double[]) _doubleMap.get(key) ;
+      if( a ==null ) return 0 ;
+      return a.length ;
+   }
+   
    public int getNString(String key)
    {
       String[] a = (String[]) _stringMap.get(key) ;
@@ -129,6 +163,14 @@ public class ILCParameters extends ILCObject implements LCParameters
       _floatMap.put(key,values) ;
    }
    
+   public void setValue(String key, double value)
+   {
+      checkAccess() ;
+      double[] values =
+      { value } ;
+      _doubleMap.put(key,values) ;
+   }
+   
    public void setValue(String key, String value)
    {
       checkAccess() ;
@@ -147,6 +189,12 @@ public class ILCParameters extends ILCObject implements LCParameters
    {
       checkAccess() ;
       _floatMap.put(key,values) ;
+   }
+   
+   public void setValues(String key, double[] values)
+   {
+      checkAccess() ;
+      _doubleMap.put(key,values) ;
    }
    
    public void setValues(String key, String[] values)

--- a/src/java/hep/lcio/implementation/sio/SIOLCParameters.java
+++ b/src/java/hep/lcio/implementation/sio/SIOLCParameters.java
@@ -40,6 +40,17 @@ class SIOLCParameters extends ILCParameters
 	  _floatMap.put( key , fv ) ; 
 	}	
 
+	int nDoubleParameters =  in.readInt(); 
+	for (int i = 0; i < nDoubleParameters; i++) {
+	  String key = in.readString();
+	  int nDouble = in.readInt() ;
+	  double[] fv = new double[nDouble] ;
+	  for (int j = 0; j < nDouble; j++) {
+		  fv[j] = in.readDouble() ;
+	  }
+	  _doubleMap.put( key , fv ) ; 
+	}	
+
 	int nStringParameters =  in.readInt(); 
 	for (int i = 0; i < nStringParameters; i++) {
 	  String key = in.readString();
@@ -83,6 +94,18 @@ class SIOLCParameters extends ILCParameters
 	  out.writeInt(nVal) ;
 	  for (int j = 0; j < nVal; j++) {
 		 out.writeFloat( v[j] ) ; 
+	  }
+	}	
+	keys = params.getDoubleKeys() ;
+	nKeys = keys.length;  
+	out.writeInt( nKeys ) ;
+	for (int i = 0; i < nKeys; i++) {
+	  out.writeString( keys[i] ) ;
+	  double[] v = params.getDoubleVals( keys[i] ) ;
+	  int nVal = v.length ;
+	  out.writeInt(nVal) ;
+	  for (int j = 0; j < nVal; j++) {
+		 out.writeDouble( v[j] ) ; 
 	  }
 	}	
 	keys = params.getStringKeys() ;


### PR DESCRIPTION

BEGINRELEASENOTES
- add support for storing double values in LCParameters
    - used in run, event and collection parameters
    - example 

```cpp
	DoubleVec dv ;
	dv.push_back( 1.111111111111111111111111111111111111111111111111 ) ;
	dv.push_back( 2.222222222222222222222222222222222222222222222222 ) ;
	dv.push_back( 3.333333333333333333333333333333333333333333333333 ) ;
	evt->parameters().setValues( "SomeDoubleNumbers" , dv ) ;

```
- should resolve #138 

ENDRELEASENOTES