### PR TITLE
Install all headers that are necessary for python bindings

### DIFF
--- a/.github/workflows/python_bindings.yml
+++ b/.github/workflows/python_bindings.yml
@@ -1,0 +1,32 @@
+name: python_bindings
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cvmfs-contrib/github-action-cvmfs@v2
+      - uses: aidasoft/run-lcg-view@v3
+        with:
+          release-platform: "LCG_101/x86_64-centos7-gcc10-opt"
+          run: |
+            mkdir build install
+            cd build
+            cmake -DCMAKE_CXX_STANDARD=17 \
+              -DBUILD_ROOTDICT=ON \
+              -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+              -DCMAKE_INSTALL_PREFIX=../install \
+              -G Ninja \
+              ..
+            ninja -k0 install
+            cd ../install
+            source ../setup.sh
+            cd ../
+            rm -r $(ls | grep -v install)
+            python $LCIO/python/examples/EventBuilder.py test.slcio 1
+            python $LCIO/python/examples/readMCParticles.py test.slcio

--- a/examples/python/readMCParticles.py
+++ b/examples/python/readMCParticles.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+#
+# This is just a simple test script to check whether the python bindings are
+# actually working as intended
+
+from __future__ import print_function, absolute_import, unicode_literals
+
+import pyLCIO as lcio
+import sys
+
+reader = lcio.IOIMPL.LCFactory.getInstance().createLCReader()
+reader.open(sys.argv[1])
+
+for event in reader:
+    mcs = event.getCollection('MCParticle')
+    for mc in mcs:
+        print(mc.getEnergy())

--- a/setup.sh
+++ b/setup.sh
@@ -4,8 +4,14 @@
 # initialize the current LCIO version by sourcing this in the top level directory
 #
 
-export LCIO=`pwd`
+export LCIO=$(pwd)
 export PATH=$LCIO/bin:$LCIO/tools:$PATH
-export LD_LIBRARY_PATH=$LCIO/lib:$LD_LIBRARY_PATH
-export PYTHONPATH=$LCIO/src/python:$PYTHONPATH
-alias pylcio='python $LCIO/src/python/pylcio.py'
+for d in lib lib64; do
+    if [ -d ${LCIO}/${d} ]; then
+        export LD_LIBRARY_PATH=${LCIO}/${d}:${LD_LIBRARY_PATH}
+    fi
+done
+export PYTHONPATH=$LCIO/python:$PYTHONPATH
+alias pylcio='python $LCIO/python/pylcio.py'
+# Necessary for python bindings to work properly
+export CPATH=$LCIO:$LCIO/include:$CPATH

--- a/sio/CMakeLists.txt
+++ b/sio/CMakeLists.txt
@@ -30,10 +30,17 @@ FILE( GLOB_RECURSE SIO_SRCS src/*.cc )
 
 ADD_DEFINITIONS( "-DSIO_LOGLVL=0" )
 ADD_SHARED_LIBRARY( sio ${SIO_SRCS} )
-TARGET_INCLUDE_DIRECTORIES( sio PUBLIC include )
+TARGET_INCLUDE_DIRECTORIES( sio PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 TARGET_INCLUDE_DIRECTORIES( sio SYSTEM PUBLIC ${ZLIB_INCLUDE_DIR} )
 TARGET_LINK_LIBRARIES( sio ${ZLIB_LIBRARIES} )
 INSTALL_SHARED_LIBRARY( sio DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+
+# Install the sio headers as well. Necessary for the python bindings and also
+# for cases where others want to link against LCIO / this version of SIO
+INSTALL(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/sio DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # mimic the SIOConfig.cmake variables for the LCIO project
 SET( SIO_VERSION                  "${SIO_VERSION}"                       CACHE STRING "The SIO version" )

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -442,6 +442,25 @@ IF( BUILD_ROOTDICT )
 
     INSTALL(FILES  ${ROOT_DICT_PCM_FILES} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+    # We need to install some headers which are necessary for the python
+    # bindings, even though these are essentially internal implementation
+    # headers only and should not be publicly reachable. However, if we do not
+    # install these then, the ROOT generated python bindings will not work if
+    # the LCIO sources are removed after the installation. See #106
+    INSTALL(FILES
+      ${CMAKE_CURRENT_LIST_DIR}/include/IOIMPL/LCEventLazyImpl.h
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/IOIMPL
+    )
+    INSTALL(FILES
+      ${CMAKE_CURRENT_LIST_DIR}/include/SIO/SIOHandlerMgr.h
+      ${CMAKE_CURRENT_LIST_DIR}/include/SIO/SIOObjectHandler.h
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SIO
+    )
+
+    INSTALL(DIRECTORY
+      ${CMAKE_CURRENT_LIST_DIR}/include/pre-generated
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 ENDIF()
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Install all the necessary headers to make the python bindings work, even if the sources are removed after installation. Fixes #106

ENDRELEASENOTES

