### PR TITLE
Bump minimum and default c++ version to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,13 @@ option(LCIO_SET_RPATH   "Link libraries with built-in RPATH (run-time search pat
 
 # load default settings from ILCSOFT_CMAKE_MODULES
 INCLUDE( ilcsoft_default_settings )
-IF( NOT CMAKE_CXX_STANDARD )
-  SET( CMAKE_CXX_STANDARD 14 )
-ENDIF()
+
+# ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
+SET(CMAKE_CXX_STANDARD 17 CACHE STRING "")
+
+if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
+  MESSAGE(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD} (need >= 17)")
+endif()
 SET( CMAKE_CXX_STANDARD_REQUIRED ON )
 
 # lcio.jar


### PR DESCRIPTION

BEGINRELEASENOTES
- Make c++17 the default and minimum c++ version for building LCIO. All "major builds" of LCIO have been using c++17 for at least a few years now, so this should not be a big issue.

ENDRELEASENOTES