### PR TITLE
Fix compiler warning

### DIFF
--- a/src/cpp/src/UTIL/lXDR.cc
+++ b/src/cpp/src/UTIL/lXDR.cc
@@ -73,10 +73,10 @@ void lXDR::setFileName(const char *filename, bool open_for_write)
       _fileName = 0;
    }
 
-   int n = strlen(filename);
-   _fileName = new char [n + 1];
+   // Include the final \0, strncpy will append it in _fileName
+   int n = strlen(filename) + 1;
+   _fileName = new char [n];
    strncpy(_fileName, filename, n);
-   _fileName[n] = '\0';
 
    _openForWrite = open_for_write;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a compiler warning about `strncpy` usage

ENDRELEASENOTES

There is this warning when compiling:

``` shell
LCIO/src/cpp/src/UTIL/lXDR.cc: In member function ‘void UTIL::lXDR::setFileName(const char*, bool)’:
LCIO/src/cpp/src/UTIL/lXDR.cc:78:11: warning: ‘char* strncpy(char*, const char*, size_t)’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   78 |    strncpy(_fileName, filename, n);
      |    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
LCIO/src/cpp/src/UTIL/lXDR.cc:76:18: note: length computed here
   76 |    int n = strlen(filename);
```

this is being picky about how the copying is done, because we can use `strncpy` to copy the `\0` character without having to do it manually (`strncpy` will put the `\0` once it exhausts the second argument (source)). All tests pass, but I'm not sure this is tested for explicitly.

I think the rest of the warnings will be gone when #151 is done

Simple example:
``` cpp
int main () {
  char src[6] = "hello";
  int n = strlen(src) + 1;
  char *dst = new char [n];
  strncpy(dst, src, n);
  cout << dst << " " << (dst[n-1] == '\0') << endl; 
}
```
Output:
``` cpp
hello 1
```
