### PR TITLE
Fix bug and change interface of getMaxWeight and move track/cluster encoding parts to MarlinUtil

### DIFF
--- a/src/cpp/include/UTIL/LCRelationNavigator.h
+++ b/src/cpp/include/UTIL/LCRelationNavigator.h
@@ -73,14 +73,20 @@ namespace UTIL {
      *  LCObject is of type getToType(). Different comparator function can be specified
      *  in a second argument analogous to e.g. std::min() overload.
      */
+
+    template<typename CompareF>
+    size_t getMaxWeightIdx(const std::vector<float>& weights, CompareF&& compare) {
+        const auto maxWeightIt = std::max_element(weights.begin(), weights.end(), compare);
+        return std::distance(weights.begin(), maxWeightIt);
+    }
+
     template <typename CompareF = std::less<float> >
     const EVENT::LCObject* getRelatedToMaxWeightObject(EVENT::LCObject* from, CompareF&& compare = CompareF() ) const{
         const auto& objects = getRelatedToObjects(from);
         if ( objects.empty() ) return nullptr;
 
         const auto& weights = getRelatedToWeights(from);
-        const auto maxWeightIt = std::max_element(weights.begin(), weights.end(), compare);
-        int i = std::distance(weights.begin(), maxWeightIt);
+        size_t i = getMaxWeightIdx(weights, compare);
         return objects[i];
     }
 
@@ -90,13 +96,11 @@ namespace UTIL {
      */
     template <typename CompareF = std::less<float> >
     const EVENT::LCObject* getRelatedFromMaxWeightObject(EVENT::LCObject* to, CompareF&& compare = CompareF() ) const{
-        const auto& objects = getRelatedToObjects(to);
+        const auto& objects = getRelatedFromObjects(to);
         if ( objects.empty() ) return nullptr;
 
-        const auto& weights = getRelatedToWeights(to);
-        const auto maxWeightIt = std::max_element(weights.begin(), weights.end(), compare);
-
-        int i = std::distance(weights.begin(), maxWeightIt);
+        const auto& weights = getRelatedFromWeights(to);
+        size_t i = getMaxWeightIdx(weights, compare);
         return objects[i];
     }
 
@@ -119,10 +123,10 @@ namespace UTIL {
      */
     template <typename CompareF = std::less<float> >
     float getRelatedFromMaxWeight(EVENT::LCObject* to, CompareF&& compare = CompareF() ) const {
-        const auto& objects = getRelatedToObjects(to);
+        const auto& objects = getRelatedFromObjects(to);
         if ( objects.empty() ) return 0.;
 
-        const auto& weights = getRelatedToWeights(to);
+        const auto& weights = getRelatedFromWeights(to);
         return *std::max_element(weights.begin(), weights.end(), compare);
     }
 

--- a/src/cpp/include/UTIL/LCRelationNavigator.h
+++ b/src/cpp/include/UTIL/LCRelationNavigator.h
@@ -70,8 +70,8 @@ namespace UTIL {
     const EVENT::FloatVec & getRelatedFromWeights(EVENT::LCObject * to) const ;
 
     /** Object with a highest weight that the given from-object is related to.
-     *  LCObject is of type getToType(). Different comparator function can be specified
-     *  in a second argument analogous to e.g. std::min() overload.
+     *  LCObject is of type getToType(). CompareF is a comparison function object
+     *  with the signature bool(float a, float b) which returns ​true if a is less than b.
      */
 
     template<typename CompareF>
@@ -91,8 +91,8 @@ namespace UTIL {
     }
 
     /** From-object related to the given object with a highest weight (the inverse relationship).
-     *  LCObject is of type getFromType(). Different comparator function can be specified
-     *  in a second argument analogous to e.g. std::min() overload.
+     *  LCObject is of type getFromType(). CompareF is a comparison function object
+     *  with the signature bool(float a, float b) which returns ​true if a is less than b.
      */
     template <typename CompareF = std::less<float> >
     const EVENT::LCObject* getRelatedFromMaxWeightObject(EVENT::LCObject* to, CompareF&& compare = CompareF() ) const{
@@ -105,8 +105,8 @@ namespace UTIL {
     }
 
     /** The highest weight of the relations returned by a call to getRelatedToObjects(from).
-     * @see getRelatedToObjects. Different comparator function can be specified
-     *  in a second argument analogous to e.g. std::min() overload.
+     * @see getRelatedToObjects. CompareF is a comparison function object
+     *  with the signature bool(float a, float b) which returns ​true if a is less than b.
      */
     template <typename CompareF = std::less<float> >
     float getRelatedToMaxWeight(EVENT::LCObject* from, CompareF&& compare = CompareF() ) const {
@@ -118,8 +118,8 @@ namespace UTIL {
     }
 
     /** The highest weight of the relations returned by a call to getRelatedFromObjects(to). 
-     * @see getRelatedFromObjects. Different comparator function can be specified
-     *  in a second argument analogous to e.g. std::min() overload.
+     * @see getRelatedFromObjects. CompareF is a comparison function object
+     *  with the signature bool(float a, float b) which returns ​true if a is less than b.
      */
     template <typename CompareF = std::less<float> >
     float getRelatedFromMaxWeight(EVENT::LCObject* to, CompareF&& compare = CompareF() ) const {

--- a/src/cpp/src/UTIL/LCRelationNavigator.cc
+++ b/src/cpp/src/UTIL/LCRelationNavigator.cc
@@ -1,6 +1,5 @@
 #include "UTIL/LCRelationNavigator.h"
 
-#include <algorithm>
 #include <cassert>
 #include "IMPL/LCCollectionVec.h"
 #include "IMPL/LCFlagImpl.h"
@@ -66,56 +65,6 @@ namespace UTIL{
   const  EVENT::FloatVec & LCRelationNavigator::getRelatedFromWeights(EVENT::LCObject * to) const {
 
     return _rMap[ to ].second ;
-  }
-
-  auto getMaxWeightIt(const EVENT::FloatVec& weights, const std::string& weightType) {
-    if (weightType == "track") {
-      std::max_element(weights.begin(), weights.end(), [](float a, float b) {
-        return (int(a) % 10000) / 1000. < (int(b) % 10000) / 1000.;
-      });
-    } else if (weightType == "cluster") {
-      std::max_element(weights.begin(), weights.end(), [](float a, float b) {
-        return (int(a) / 10000) / 1000. < (int(b) / 10000) /1000.;
-      });
-    }
-    return std::max_element(weights.begin(), weights.end());
-  }
-
-  const EVENT::LCObject* LCRelationNavigator::getRelatedToMaxWeightObject(EVENT::LCObject* from, const std::string& weightType) const {
-      const auto& objects = getRelatedToObjects(from);
-      if ( objects.empty() ) return nullptr;
-
-      const auto& weights = getRelatedToWeights(from);
-      const auto maxWeightIt = getMaxWeightIt(weights, weightType);
-      int i = std::distance(weights.begin(), maxWeightIt);
-      return objects[i];
-  }
-
-  const EVENT::LCObject* LCRelationNavigator::getRelatedFromMaxWeightObject(EVENT::LCObject* to, const std::string& weightType) const {
-      const auto& objects = getRelatedToObjects(to);
-      if ( objects.empty() ) return nullptr;
-
-      const auto& weights = getRelatedToWeights(to);
-      const auto maxWeightIt = getMaxWeightIt(weights, weightType);
-
-      int i = std::distance(weights.begin(), maxWeightIt);
-      return objects[i];
-  }
-
-  float LCRelationNavigator::getRelatedToMaxWeight(EVENT::LCObject* from, const std::string& weightType) const {
-      const auto& objects = getRelatedToObjects(from);
-      if ( objects.empty() ) return 0.;
-
-      const auto& weights = getRelatedToWeights(from);
-      return *getMaxWeightIt(weights, weightType);
-  }
-
-  float LCRelationNavigator::getRelatedFromMaxWeight(EVENT::LCObject* to, const std::string& weightType) const {
-      const auto& objects = getRelatedToObjects(to);
-      if ( objects.empty() ) return 0.;
-
-      const auto& weights = getRelatedToWeights(to);
-      return *getMaxWeightIt(weights, weightType);
   }
 
   void LCRelationNavigator::addRelation(EVENT::LCObject * from, 


### PR DESCRIPTION
Make getMaxWeight functionality templated that allows passing any comparator. Moving track/caluster weight encodings functionality into MarlinUtil

Added with LCIO v02-18 (https://github.com/iLCSoft/LCIO/releases/tag/v02-18) utility methods to extract the highest weight for LCRelationNavigator are not working properly.

1. `getMaxWeightIt()` must return max_element in every if branch, otherwise passed "weight" parameter is just ignored
https://github.com/iLCSoft/LCIO/blob/2a0d5d14182888486c06f54ccb49b354856286b0/src/cpp/src/UTIL/LCRelationNavigator.cc#L72-L81
2. Every new function that uses `std::string& weightType` as an argument, must have an empty string as a default.

We have discussed with @tmadlener that it would be nice to keep the functionality as general as possible in LCIO and have track/cluster specific weight encoding parts in the MarlinUtil, as these encodings are defined only to some specific LCRelation collections which are created by MarlinReco.

This PR fixes bugs described above and changes the interface to be more generic allowing an arbitrary ~comparator~ function as an argument instead of previously string parameter.

Two specific comparator function for track and cluster weights will be added to the MarlinUtil soon.


BEGINRELEASENOTES

- `getRelatedTo(From)MaxWeightObject()` and `getRelatedTo(From)MaxWeight()` now accept generic decode function of `float(float)` signature as a second argument, which specifies how to decode the weight. Default option is identity function (just compares weights as they are).
- Helper functions to decode and encode "track"/"cluster" specific weights from PFO-MCParticle LCRelation collection are added to MarlinUtil in [MarlinUtil#36](https://github.com/iLCSoft/MarlinUtil/pull/36).

ENDRELEASENOTES