### PR TITLE
Add Key4hep based CI workflow

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,30 @@
+name: key4hep
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ["sw.hsf.org/key4hep",
+                  "sw-nightlies.hsf.org/key4hep"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
+      with:
+        container: centos7
+        view-path: /cvmfs/${{ matrix.release }}
+        run: |
+          mkdir build install
+          cd build
+          cmake -DCMAKE_CXX_STANDARD=17 \
+            -DBUILD_ROOTDICT=ON \
+            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            ..
+          make -k
+          make install
+          ctest --output-on-failure

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -22,7 +22,7 @@ jobs:
           cd build
           cmake -DCMAKE_CXX_STANDARD=17 \
             -DBUILD_ROOTDICT=ON \
-            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror " \
             -DCMAKE_INSTALL_PREFIX=../install \
             ..
           make -k

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
               "LCG_102/x86_64-centos7-clang12-opt",
               "LCG_102/x86_64-ubuntu2004-gcc9-opt"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
           cd build
           cmake -DCMAKE_CXX_STANDARD=17 \
             -DBUILD_ROOTDICT=ON \
-            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" \
             -DCMAKE_INSTALL_PREFIX=../install \
             ..
           make -k

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         LCG: ["LCG_98/x86_64-centos7-gcc10-opt"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install CVMFS
       run: |
         wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb

--- a/.github/workflows/python_bindings.yml
+++ b/.github/workflows/python_bindings.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: aidasoft/run-lcg-view@v4
         with:

--- a/.github/workflows/python_bindings.yml
+++ b/.github/workflows/python_bindings.yml
@@ -19,7 +19,7 @@ jobs:
             cd build
             cmake -DCMAKE_CXX_STANDARD=17 \
               -DBUILD_ROOTDICT=ON \
-              -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" \
+              -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror " \
               -DCMAKE_INSTALL_PREFIX=../install \
               -G Ninja \
               ..

--- a/src/cpp/include/IMPL/AccessChecked.h
+++ b/src/cpp/include/IMPL/AccessChecked.h
@@ -22,7 +22,7 @@ namespace IMPL {
     
   public:
     AccessChecked() ;
-    virtual ~AccessChecked() { /* nop */; }
+    virtual ~AccessChecked() = default;
     virtual int simpleUID() const { return _id ; }
 
   protected:

--- a/src/cpp/include/IMPL/TrackStateImpl.h
+++ b/src/cpp/include/IMPL/TrackStateImpl.h
@@ -35,7 +35,7 @@ namespace IMPL {
 
     
     /// Destructor.
-    virtual ~TrackStateImpl() ; 
+    virtual ~TrackStateImpl() = default;
     
 
     virtual int id() const { return simpleUID() ; }

--- a/src/cpp/include/UTIL/LCFourVector.h
+++ b/src/cpp/include/UTIL/LCFourVector.h
@@ -28,7 +28,7 @@ namespace UTIL {
     const TT* _lcObj = nullptr ;
     
   public: 
-    virtual ~LCFourVector() { /*no_op*/; } 
+    virtual ~LCFourVector() = default;
     
     LCFourVector(const LCFourVector& ) = default ;
     LCFourVector& operator=(const LCFourVector& ) = default ;

--- a/src/cpp/include/UTIL/LCFourVector.h
+++ b/src/cpp/include/UTIL/LCFourVector.h
@@ -6,11 +6,6 @@
 #include "CLHEP/Vector/LorentzVector.h"
 
 
-// CLHEP 1.9 and higher introduce a namespace:
-namespace CLHEP{}  
-using namespace CLHEP ;
-
-
 namespace UTIL {
   
   
@@ -27,7 +22,7 @@ namespace UTIL {
    * @version Mar 12, 2004
    */
   template<class TT> 
-  class LCFourVector :  public HepLorentzVector {
+  class LCFourVector :  public CLHEP::HepLorentzVector {
 
   protected: 
     const TT* _lcObj = nullptr ;

--- a/src/cpp/include/UTIL/LCFourVector.icc
+++ b/src/cpp/include/UTIL/LCFourVector.icc
@@ -3,23 +3,20 @@
 #include "Exceptions.h"
 
 
-using namespace EVENT;
-using namespace IMPL;
-
 namespace UTIL{
   
 
-  typedef LCFourVector<MCParticle> MCParticle4V ;
-  typedef LCFourVector<MCParticleImpl> MCParticleI4V ;
+  typedef LCFourVector<EVENT::MCParticle> MCParticle4V ;
+  typedef LCFourVector<IMPL::MCParticleImpl> MCParticleI4V ;
   
-  typedef LCFourVector<ReconstructedParticle> ReconstructedParticle4V ;
-  typedef LCFourVector<ReconstructedParticleImpl> ReconstructedParticleI4V ;
+  typedef LCFourVector<EVENT::ReconstructedParticle> ReconstructedParticle4V ;
+  typedef LCFourVector<IMPL::ReconstructedParticleImpl> ReconstructedParticleI4V ;
 
 
   // specializations for the different LCObjects that have 4 vector information
 
   template<>
-  inline LCFourVector<MCParticle>::LCFourVector( const MCParticle* mcPart ) : 
+  inline LCFourVector<EVENT::MCParticle>::LCFourVector( const EVENT::MCParticle* mcPart ) :
      HepLorentzVector(mcPart->getMomentum()[0],
 		     mcPart->getMomentum()[1],
 		     mcPart->getMomentum()[2],
@@ -28,12 +25,12 @@ namespace UTIL{
   {
   }
   template<>
-  inline LCFourVector<MCParticle>::LCFourVector(const LCObject* lcObj){
+  inline LCFourVector<EVENT::MCParticle>::LCFourVector(const EVENT::LCObject* lcObj){
     
-    _lcObj = dynamic_cast<const MCParticle* >( lcObj ) ;
+    _lcObj = dynamic_cast<const EVENT::MCParticle* >( lcObj ) ;
 
     if( _lcObj == 0 )
-      throw Exception("Dynamic cast failed for LCFourVector() !") ;
+      throw EVENT::Exception("Dynamic cast failed for LCFourVector() !") ;
 
     const double* p =  _lcObj->getMomentum() ;
     setPx( p[0] ) ;
@@ -45,7 +42,7 @@ namespace UTIL{
   }
 
   template<>
-  inline LCFourVector<ReconstructedParticle>::LCFourVector(const ReconstructedParticle* part ): 
+  inline LCFourVector<EVENT::ReconstructedParticle>::LCFourVector(const EVENT::ReconstructedParticle* part ):
     HepLorentzVector(part->getMomentum()[0],
 		     part->getMomentum()[1],
 		     part->getMomentum()[2],
@@ -54,12 +51,12 @@ namespace UTIL{
   {
   }
   template<>
-  inline LCFourVector<ReconstructedParticle>::LCFourVector(const LCObject* lcObj){
+  inline LCFourVector<EVENT::ReconstructedParticle>::LCFourVector(const EVENT::LCObject* lcObj){
     
-    _lcObj = dynamic_cast<const ReconstructedParticle* >( lcObj ) ;
+    _lcObj = dynamic_cast<const EVENT::ReconstructedParticle* >( lcObj ) ;
 
     if( _lcObj == 0 )
-      throw Exception("Dynamic cast failed for LCFourVector() !") ;
+      throw EVENT::Exception("Dynamic cast failed for LCFourVector() !") ;
 
     const double* p =  _lcObj->getMomentum() ;
     setPx( p[0] ) ;

--- a/src/cpp/include/UTIL/LCWarning.h
+++ b/src/cpp/include/UTIL/LCWarning.h
@@ -39,7 +39,6 @@ private:
     ~LCWarning(); //{}
     LCWarning( const LCWarning& ) ;
     LCWarning & operator=(const LCWarning &);
-    static LCWarning& instance ;
 
 
     struct _warning_cfg_struct{

--- a/src/cpp/include/pre-generated/EVENT/CalorimeterHit.h
+++ b/src/cpp/include/pre-generated/EVENT/CalorimeterHit.h
@@ -35,7 +35,7 @@ class CalorimeterHit : public LCObject {
 
 public: 
     /// Destructor.
-    virtual ~CalorimeterHit() { /* nop */; }
+    virtual ~CalorimeterHit() = default;
 
 
     /** Useful typedef for template programming with LCIO */

--- a/src/cpp/include/pre-generated/EVENT/LCObject.h
+++ b/src/cpp/include/pre-generated/EVENT/LCObject.h
@@ -31,7 +31,7 @@ class LCObject : public LCRTRelations {
 
 public: 
     /// Destructor.
-    virtual ~LCObject() { /* nop */; }
+    virtual ~LCObject() = default;
 
     /** Returns an object id for internal (debugging) use in LCIO.
      */

--- a/src/cpp/include/pre-generated/EVENT/TrackState.h
+++ b/src/cpp/include/pre-generated/EVENT/TrackState.h
@@ -27,7 +27,7 @@ class TrackState : public LCObject {
 
 public: 
     /// Destructor.
-    virtual ~TrackState() { /* nop */; }
+    virtual ~TrackState() = default;
 
 
     /** Useful typedef for template programming with LCIO */

--- a/src/cpp/src/EXAMPLE/lcio_io_benchmark.cc
+++ b/src/cpp/src/EXAMPLE/lcio_io_benchmark.cc
@@ -182,7 +182,7 @@ int main(int argc, char** argv ){
         lcReader->readStream();      
       }
     }
-    catch(IO::EndOfDataException) {
+    catch(IO::EndOfDataException&) {
         
     }
 

--- a/src/cpp/src/IMPL/TrackStateImpl.cc
+++ b/src/cpp/src/IMPL/TrackStateImpl.cc
@@ -82,10 +82,6 @@ namespace IMPL {
     }
 
 
-
-
-    TrackStateImpl::~TrackStateImpl() { /* no-op */ } 
-
     int TrackStateImpl::getLocation() const { return _location ;}
     float TrackStateImpl::getD0() const { return _d0 ;}
     float TrackStateImpl::getPhi() const { return _phi ; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,7 +169,11 @@ IF( BUILD_ROOTDICT )
     SET_TESTS_PROPERTIES( t_root_anajob PROPERTIES PASS_REGULAR_EXPRESSION "50 events read from file" )
     SET_TESTS_PROPERTIES( t_root_writeTree PROPERTIES PASS_REGULAR_EXPRESSION "50 events read from file" )
     SET_TESTS_PROPERTIES( t_root_writeEventTree PROPERTIES PASS_REGULAR_EXPRESSION "50 events read from file" )
-    SET_TESTS_PROPERTIES( t_root_readEventTree PROPERTIES PASS_REGULAR_EXPRESSION "50 events read from file" )
+    SET_TESTS_PROPERTIES( t_root_readEventTree
+      PROPERTIES
+      PASS_REGULAR_EXPRESSION "50 events read from file"
+      DEPENDS t_root_writeEventTree
+      )
 
 ENDIF()
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add Key4hep release based CI workflow
- Fix remaining warnings to enable `-Werror`
- Update *checkout* action to v3, since v2 is deprecated. 
- **CLHEP >= 2.0** is now required for building the examples that use CLHEP functionality (`test_fourvector`).

ENDRELEASENOTES

- [x] Check if LCIO builds without warnings now and enable `-Werror` in CI builds.