### PR TITLE
Make proper patching of LCRelations possible

### DIFF
--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -30,12 +30,12 @@ namespace UTIL {
     virtual ~CheckCollections() = default ;
 
     /** Checks the file for missing collections - can be called repeadedly on different files.
-    The quit flag makes this function not produce any output.
+    The quiet flag makes this function not produce any output.
      */
     void checkFile( const std::string& fileName ,bool quiet= false) ;
 
     /** Checks all files for missing collections.
-    The quit flag makes this function not produce any output.
+    The quiet flag makes this function not produce any output.
      */
     void checkFiles( const std::vector<std::string>& fileNames ,bool quiet= false) ;
 

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -30,15 +30,20 @@ namespace UTIL {
     virtual ~CheckCollections() = default ;
 
     /** Checks the file for missing collections - can be called repeadedly on different files.
+    The quit flag makes this function not produce any output.
      */
-    void checkFile( const std::string& fileName ,bool minimal= false) ;
+    void checkFile( const std::string& fileName ,bool quiet= false) ;
 
     /** Checks all files for missing collections.
+    The quit flag makes this function not produce any output.
      */
-    void checkFiles( const std::vector<std::string>& fileNames ,bool minimal= false) ;
+    void checkFiles( const std::vector<std::string>& fileNames ,bool quiet= false) ;
 
     
-    /** dump result of check to stream */
+    /** dump result of check to stream
+    The minimal flag reduces the output of this function.
+     */
+
     void print(  std::ostream& os ,bool minimal= false) const ;
     
 

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -32,19 +32,18 @@ namespace UTIL {
     /** Checks the file for missing collections - can be called repeadedly on different files.
     The quiet flag makes this function not produce any output.
      */
-    void checkFile( const std::string& fileName ,bool quiet= false) ;
+    void checkFile( const std::string& fileName, bool quiet=false) ;
 
     /** Checks all files for missing collections.
     The quiet flag makes this function not produce any output.
      */
-    void checkFiles( const std::vector<std::string>& fileNames ,bool quiet= false) ;
+    void checkFiles( const std::vector<std::string>& fileNames, bool quiet=false) ;
 
     
-    /** dump result of check to stream
-    The minimal flag reduces the output of this function.
+    /** dump result of check to stream. The minimal flag reduces the output of
+     * this function.
      */
-
-    void print(  std::ostream& os ,bool minimal= false) const ;
+    void print(  std::ostream& os ,bool minimal=false) const ;
     
 
     /** Returns the collections that are not present in all events checked with checkFiles() with their names and types.

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -31,15 +31,15 @@ namespace UTIL {
 
     /** Checks the file for missing collections - can be called repeadedly on different files.
      */
-    void checkFile( const std::string& fileName ) ;
+    void checkFile( const std::string& fileName ,bool minimal= false) ;
 
     /** Checks all files for missing collections.
      */
-    void checkFiles( const std::vector<std::string>& fileNames ) ;
+    void checkFiles( const std::vector<std::string>& fileNames ,bool minimal= false) ;
 
     
     /** dump result of check to stream */
-    void print(  std::ostream& os ) const ;
+    void print(  std::ostream& os ,bool minimal= false) const ;
     
 
     /** Returns the collections that are not present in all events checked with checkFiles() with their names and types.

--- a/src/cpp/src/EXAMPLE/check_missing_cols.cc
+++ b/src/cpp/src/EXAMPLE/check_missing_cols.cc
@@ -16,7 +16,7 @@ int main(int argc, char** argv ){
   // read file names from command line (only argument) 
   bool minimal = false ;
   if( argc < 2) {
-    std::cout << " usage:  check_missing_cols <input-file1> [[input-file2],...]" << std::endl << std::endl ;
+    std::cout << " usage:  check_missing_cols [--minimal] <input-file1> [[input-file2],...]" << std::endl << std::endl ;
     exit(1) ;
   }
   for(int i=1 ; i < argc ; i++){

--- a/src/cpp/src/EXAMPLE/check_missing_cols.cc
+++ b/src/cpp/src/EXAMPLE/check_missing_cols.cc
@@ -14,35 +14,45 @@ static std::vector<std::string> FILEN ;
 int main(int argc, char** argv ){
 
   // read file names from command line (only argument) 
+  bool minimal = false ;
   if( argc < 2) {
     std::cout << " usage:  check_missing_cols <input-file1> [[input-file2],...]" << std::endl << std::endl ;
     exit(1) ;
   }
   for(int i=1 ; i < argc ; i++){
+      if (argv[i] == std::string("--minimal")){
+        minimal = true ;
+        continue ;
+      }
+
       FILEN.push_back( argv[i] )  ;
   }
   int nFiles = argc-1 ;
+  if (minimal == true){
+    nFiles --;
+  }
   
-  MT::LCReader lcReader(0) ; 
-  
-  std::cout << "patch_events:  will open and read from files: " << std::endl ;  
-
-  for(int i=0 ; i < nFiles ; i++){
-
-    lcReader.open( FILEN[i] ) ;
+  if (minimal == false){
+    MT::LCReader lcReader(0) ; 
     
-    std::cout  << std::endl <<  "     "  << FILEN[i] 
-	  <<       " [ nEvt = "  <<  lcReader.getNumberOfEvents() << " ] "
-	  << std::endl ; 
-    
-    lcReader.close() ;
-  }  
+    std::cout << "patch_events:  will open and read from files: " << std::endl ;  
 
+    for(int i=0 ; i < nFiles ; i++){
+
+      lcReader.open( FILEN[i] ) ;
+      
+      std::cout  << std::endl <<  "     "  << FILEN[i] 
+      <<       " [ nEvt = "  <<  lcReader.getNumberOfEvents() << " ] "
+      << std::endl ; 
+      
+      lcReader.close() ;
+    }  
+  }
   UTIL::CheckCollections colCheck ;
   
-  colCheck.checkFiles( FILEN ) ;
+  colCheck.checkFiles( FILEN ,minimal) ;
 
-  colCheck.print( std::cout ) ;
+  colCheck.print( std::cout ,minimal) ;
   
 
   return 0 ;

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -47,7 +47,7 @@ namespace UTIL{
       const auto& toType = params.getStringVal("ToType");
       if (quiet == false){
         if (fromType == ""|| toType == ""){
-          std::cout<< "WARNING! : Relation " << name <<" does not have the 'fromType' and 'toType' set."<<std::endl;
+          std::cout<< "WARNING! : Relation " << name <<" does not have the 'FromType' and 'ToType' set."<<std::endl;
         }
       }
       typeString = "LCRelation["+fromType+","+toType+"]";

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -9,13 +9,13 @@
 
 namespace UTIL{
 
-  void CheckCollections::checkFiles( const std::vector<std::string>& fileNames ,bool minimal ){
+  void CheckCollections::checkFiles( const std::vector<std::string>& fileNames ,bool quiet ){
 
     for( auto n : fileNames )
-      checkFile( n ,minimal) ;
+      checkFile( n ,quiet) ;
   }
 
-  void CheckCollections::checkFile( const std::string& fileName ,bool minimal){
+  void CheckCollections::checkFile( const std::string& fileName ,bool quiet){
 
     MT::LCReader lcReader(MT::LCReader::directAccess) ; 
     lcReader.open( fileName ) ;
@@ -45,7 +45,7 @@ namespace UTIL{
       const auto& params = fullcol->getParameters();
       const auto& fromType = params.getStringVal("FromType");
       const auto& toType = params.getStringVal("ToType");
-      if (minimal == false){
+      if (quiet == false){
         if (fromType == ""|| toType == ""){
           std::cout<< "WARNING! : Realtion " << name <<" does not have the 'fromType' and 'toType' set."<<std::endl;
         }
@@ -98,8 +98,8 @@ namespace UTIL{
 	evt->getCollection( c.first ) ;
 
       } catch( EVENT::DataNotAvailableException& e) {
-      
-      if (c.second.size()> 11){
+      //10 is the length of the String LCRelation after which the bracket is and the "ToType" and "FromType" start.
+      if (c.second.size()> 10){
       if (c.second[10] != '['){
 	      evt->addCollection( new IMPL::LCCollectionVec(c.second), c.first ) ;
         }
@@ -129,21 +129,31 @@ namespace UTIL{
     os << "     collections that are not in all events :  [# events where col is present]" << std::endl ;
     os << " ================================================================ " << std::endl ;
     }
-    for(auto e : _map ){
-      
-      if( e.second.second != _nEvents )
-	os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << " [" <<  e.second.second << "]"<< std::endl ;
+    if (minimal == false){
+      for(auto e : _map ){
+        
+        if( e.second.second != _nEvents )
+    os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << " [" <<  e.second.second << "]"<< std::endl ;
+      }
     }
+
     if (minimal == false){
     os << " ================================================================ " << std::endl ;
     os << "     collections that are in all events : " << std::endl ;
     os << " ================================================================ " << std::endl ;
     }
-    
-    for(auto e : _map ){
+    if (minimal == false){
+      for(auto e : _map ){
+        
+        if( e.second.second == _nEvents )
+    os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << "  [" <<  e.second.second << "]"<< std::endl ;
+      }
+    }
+    else{
+      for(auto e : _map ){
       
-      if( e.second.second == _nEvents )
-	os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << "  [" <<  e.second.second << "]"<< std::endl ;
+	os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << std::endl ;
+    }
     }
     if (minimal == false){
     os << " ================================================================ " << std::endl ;

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -9,13 +9,13 @@
 
 namespace UTIL{
 
-  void CheckCollections::checkFiles( const std::vector<std::string>& fileNames ){
+  void CheckCollections::checkFiles( const std::vector<std::string>& fileNames ,bool minimal ){
 
     for( auto n : fileNames )
-      checkFile( n ) ;
+      checkFile( n ,minimal) ;
   }
 
-  void CheckCollections::checkFile( const std::string& fileName ){
+  void CheckCollections::checkFile( const std::string& fileName ,bool minimal){
 
     MT::LCReader lcReader(MT::LCReader::directAccess) ; 
     lcReader.open( fileName ) ;
@@ -45,8 +45,10 @@ namespace UTIL{
       const auto& params = fullcol->getParameters();
       const auto& fromType = params.getStringVal("FromType");
       const auto& toType = params.getStringVal("ToType");
-      if (fromType == ""|| toType == ""){
-        std::cout<< "WARNING! : Realtion " << name <<" does not have the 'fromType' and 'toType' set."<<std::endl;
+      if (minimal == false){
+        if (fromType == ""|| toType == ""){
+          std::cout<< "WARNING! : Realtion " << name <<" does not have the 'fromType' and 'toType' set."<<std::endl;
+        }
       }
       typeString = "LCRelation["+fromType+","+toType+"]";
     }
@@ -118,33 +120,34 @@ namespace UTIL{
   }
 
   
-  void CheckCollections::print(  std::ostream& os ) const {
+  void CheckCollections::print(  std::ostream& os ,bool minimal) const {
 
     unsigned width = 50 ;
-
+    if (minimal == false){
     os << " ================================================================ " << std::endl ;
     os << std::endl <<  "  " <<  _nEvents << " events read " << std::endl  ;
     os << "     collections that are not in all events :  [# events where col is present]" << std::endl ;
     os << " ================================================================ " << std::endl ;
-    
+    }
     for(auto e : _map ){
       
       if( e.second.second != _nEvents )
 	os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << " [" <<  e.second.second << "]"<< std::endl ;
     }
-    
+    if (minimal == false){
     os << " ================================================================ " << std::endl ;
     os << "     collections that are in all events : " << std::endl ;
     os << " ================================================================ " << std::endl ;
-    
+    }
     
     for(auto e : _map ){
       
       if( e.second.second == _nEvents )
 	os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << "  [" <<  e.second.second << "]"<< std::endl ;
     }
+    if (minimal == false){
     os << " ================================================================ " << std::endl ;
-
+    }
   }
 
 }

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -100,7 +100,7 @@ namespace UTIL{
 
   void CheckCollections::patchCollections(EVENT::LCEvent* evt ) const {
 
-    for(auto c : _patchCols ){
+    for(const auto& c : _patchCols ){
 
       try{
         auto* coll = evt->getCollection( c.first ) ;

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -9,13 +9,13 @@
 
 namespace UTIL{
 
-  void CheckCollections::checkFiles( const std::vector<std::string>& fileNames ,bool quiet ){
+  void CheckCollections::checkFiles( const std::vector<std::string>& fileNames, bool quiet){
 
     for( auto n : fileNames )
       checkFile( n ,quiet) ;
   }
 
-  void CheckCollections::checkFile( const std::string& fileName ,bool quiet){
+  void CheckCollections::checkFile( const std::string& fileName, bool quiet){
 
     MT::LCReader lcReader(MT::LCReader::directAccess) ; 
     lcReader.open( fileName ) ;
@@ -31,16 +31,18 @@ namespace UTIL{
 	if( it == _map.end() ){
 
 	  auto col = evt->getCollection( name ) ;
-    /* If the type of a collection is LCRelation we want to read the entire collections instead of just the header to get the 'ToType' and 'FromType'.  
-    * setReadCollectionNames({name}) allows reading of only certain collections by name instead of an entire event.
-    * This flag has to be unset after reading in order for the reading of the headers to function properly.
-    */
+    // If the type of a collection is LCRelation we want to read the entire
+    //  collections instead of just the header to get the 'ToType' and
+    //  'FromType'. setReadCollectionNames({name}) allows reading of only
+    //  certain collections by name instead of an entire event. This flag has to
+    //  be unset after reading in order for the reading of the headers to
+    //  function properly.
     std::string typeString;
     if (col->getTypeName() == "LCRelation"){     
       lcReader.setReadCollectionNames({name});
-      
       auto fullEvt = lcReader.readEvent(evt->getRunNumber(), evt->getEventNumber());
       lcReader.setReadCollectionNames({});
+
       auto fullcol = fullEvt->getCollection( name ) ;
       const auto& params = fullcol->getParameters();
       const auto& fromType = params.getStringVal("FromType");

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -31,9 +31,9 @@ namespace UTIL{
 	if( it == _map.end() ){
 
 	  auto col = evt->getCollection( name ) ;
-    /* If the type of a collection is LCRelation we use want to read the entire collections instead of just the header to get the 'toType' and 'fromType'.  
-    * setReadCollectionNames({name}) allows reading of onlz certain colloctions by name instead of an entire event.
-    * This flag has to be unset after reading in order for the reading of the headers to function.
+    /* If the type of a collection is LCRelation we want to read the entire collections instead of just the header to get the 'ToType' and 'FromType'.  
+    * setReadCollectionNames({name}) allows reading of only certain collections by name instead of an entire event.
+    * This flag has to be unset after reading in order for the reading of the headers to function properly.
     */
     std::string typeString;
     if (col->getTypeName() == "LCRelation"){     

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -47,7 +47,7 @@ namespace UTIL{
       const auto& toType = params.getStringVal("ToType");
       if (quiet == false){
         if (fromType == ""|| toType == ""){
-          std::cout<< "WARNING! : Realtion " << name <<" does not have the 'fromType' and 'toType' set."<<std::endl;
+          std::cout<< "WARNING! : Relation " << name <<" does not have the 'fromType' and 'toType' set."<<std::endl;
         }
       }
       typeString = "LCRelation["+fromType+","+toType+"]";


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixes to the on the fly collection patching that are necessary for the LCIO to EDM4hep standalone conversion.
  - Make `CheckCollections` check the `FromType` and `ToType` collection parameters to figure out the involved types for `LCRelations`. Add them to the output of `CheckCollections::print`
  - Make the `CheckCollectoins::patchCollections` parse these strings back for `LCRelation` collections and set them as collection parameters for collections it creates on the fly.
  - Add a `--minimal` flag to `check_missing_cols` in order to make it possible to produce outputs that can be more easily consumbed by other programs.

ENDRELEASENOTES