### PR TITLE
Use ubuntu-latest for pylint github action

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   python-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         LCG: ["LCG_98/x86_64-centos7-gcc10-opt"]


### PR DESCRIPTION

BEGINRELEASENOTES
- Upgrade `python-lint` workflow to run on `ubuntu-lates` since `ubuntu-18.04` runners have been removed.

ENDRELEASENOTES