### PR TITLE
C++20

### DIFF
--- a/src/cpp/include/IMPL/TrackStateImpl.h
+++ b/src/cpp/include/IMPL/TrackStateImpl.h
@@ -27,6 +27,7 @@ namespace IMPL {
     /** Default constructor, initializes values to 0.
      */
     TrackStateImpl() ;
+    TrackStateImpl(TrackStateImpl&&) = default ;
     TrackStateImpl(TrackStateImpl const&) = default ;
     TrackStateImpl& operator=(TrackStateImpl const&) = default ;
     TrackStateImpl(int location, float d0, float phi, float omega, float z0, float tanLambda, const float* covMatrix, const float* reference) ;

--- a/src/cpp/include/IMPL/TrackStateImpl.h
+++ b/src/cpp/include/IMPL/TrackStateImpl.h
@@ -27,6 +27,8 @@ namespace IMPL {
     /** Default constructor, initializes values to 0.
      */
     TrackStateImpl() ;
+    TrackStateImpl(TrackStateImpl const&) = default ;
+    TrackStateImpl& operator=(TrackStateImpl const&) = default ;
     TrackStateImpl(int location, float d0, float phi, float omega, float z0, float tanLambda, const float* covMatrix, const float* reference) ;
     TrackStateImpl(int location, float d0, float phi, float omega, float z0, float tanLambda, const EVENT::FloatVec& covMatrix, const float* reference) ;
     /** Copy constructor which takes as an argument an EVENT::TrackState reference */

--- a/src/cpp/include/LCRTRelations.h
+++ b/src/cpp/include/LCRTRelations.h
@@ -69,17 +69,17 @@ namespace lcrtrel_helper{
     typedef U tag ;    // this ensures that a new class instance is created for every user extension
     static const int allowed_to_call_ext = b ;
     
-    LCBaseTraits<U, T, I, D, b>(const LCBaseTraits&) = delete ;
-    LCBaseTraits<U, T, I, D, b>& operator=(const LCBaseTraits&) = delete ;
+    LCBaseTraits(const LCBaseTraits&) = delete ;
+    LCBaseTraits& operator=(const LCBaseTraits&) = delete ;
     
   public:
     /** Constructor */
-    inline LCBaseTraits<U, T, I, D, b>() {
+    inline LCBaseTraits() {
       _pointer = (ptr) I::init();
     }
     
     /** Destructor */
-    inline ~LCBaseTraits<U, T, I, D, b>() {
+    inline ~LCBaseTraits() {
       D::clean( _pointer );
     }
     
@@ -268,11 +268,11 @@ namespace lcrtrel{
     
     /** Constructor 
      */
-    LCIntExtension<U>() = default ;
+    LCIntExtension() = default ;
     
     /** Destructor 
      */
-    ~LCIntExtension<U>() = default ;
+    ~LCIntExtension() = default ;
     
     /** Extension data access */
     inline ptr& pointer() {
@@ -301,11 +301,11 @@ namespace lcrtrel{
 
     /** Constructor 
      */
-    LCFloatExtension<U>() = default ;
+    LCFloatExtension() = default ;
     
     /** Destructor 
      */
-    ~LCFloatExtension<U>() = default ;
+    ~LCFloatExtension() = default ;
     
     /** Extension data access */
     inline ptr& pointer() {
@@ -327,11 +327,11 @@ namespace lcrtrel{
     
     /** Constructor 
      */
-    LCBoolExtension<U>() = default ;
+    LCBoolExtension() = default ;
     
     /** Destructor 
      */
-    ~LCBoolExtension<U>() = default ;
+    ~LCBoolExtension() = default ;
     
     /** Extension data access */
     inline ptr& pointer() {

--- a/src/cpp/include/SIO/RunEventMap.h
+++ b/src/cpp/include/SIO/RunEventMap.h
@@ -16,6 +16,7 @@ namespace SIO {
 
     RunEvent() = default ;
     RunEvent(RunEvent const&) = default ;
+    RunEvent(RunEvent&&) = default ;
     RunEvent& operator=(RunEvent const&) = default ;
     ~RunEvent() = default ;
     RunEvent(int run, int evt): RunNum( run ), EvtNum( evt ) {}

--- a/src/cpp/include/SIO/RunEventMap.h
+++ b/src/cpp/include/SIO/RunEventMap.h
@@ -15,6 +15,8 @@ namespace SIO {
     typedef long long long64 ;
 
     RunEvent() = default ;
+    RunEvent(RunEvent const&) = default ;
+    RunEvent& operator=(RunEvent const&) = default ;
     ~RunEvent() = default ;
     RunEvent(int run, int evt): RunNum( run ), EvtNum( evt ) {}
     RunEvent(long64 runEvt): RunNum( (runEvt >> 32 ) & 0xffffffff  ), EvtNum( runEvt &  0xffffffff ) {}

--- a/src/cpp/include/UTIL/LCIterator.h
+++ b/src/cpp/include/UTIL/LCIterator.h
@@ -38,7 +38,7 @@ namespace UTIL {
   template <class T>
   class LCIterator{
   
-    LCIterator<T>() {} 
+    LCIterator() {} 
   
   public:
 
@@ -47,7 +47,7 @@ namespace UTIL {
      *  this will behave the same as an empty collection - use operator() to
      *  test, if the collection exists.
      */
-    LCIterator<T>( EVENT::LCEvent* evt, const std::string& name ) : _i(0), _col(0) {
+    LCIterator( EVENT::LCEvent* evt, const std::string& name ) : _i(0), _col(0) {
     
     
       try{
@@ -74,7 +74,7 @@ namespace UTIL {
   
     /** Constructor for the given collection.
      */
-    LCIterator<T>( const EVENT::LCCollection* col) : _i(0) , _col( col ) {
+    LCIterator( const EVENT::LCCollection* col) : _i(0) , _col( col ) {
     
       _n = (_col ? _col->getNumberOfElements() : 0 ) ;
     

--- a/src/cpp/include/pre-generated/EVENT/Cluster.h
+++ b/src/cpp/include/pre-generated/EVENT/Cluster.h
@@ -8,7 +8,6 @@
 #define EVENT_CLUSTER_H 1
 
 #include "EVENT/CalorimeterHit.h"
-#include "EVENT/Cluster.h"
 #include "EVENT/LCObject.h"
 #include "EVENT/ParticleID.h"
 #include "LCIOSTLTypes.h"

--- a/src/cpp/include/pre-generated/EVENT/LCObject.h
+++ b/src/cpp/include/pre-generated/EVENT/LCObject.h
@@ -33,6 +33,10 @@ public:
     /// Destructor.
     virtual ~LCObject() = default;
 
+    LCObject() = default ;
+    LCObject(LCObject const&) = default ;
+    LCObject& operator=(LCObject const&) = default ;
+
     /** Returns an object id for internal (debugging) use in LCIO.
      */
     virtual int id() const = 0;

--- a/src/cpp/include/pre-generated/EVENT/LCObject.h
+++ b/src/cpp/include/pre-generated/EVENT/LCObject.h
@@ -35,6 +35,7 @@ public:
 
     LCObject() = default ;
     LCObject(LCObject const&) = default ;
+    LCObject(LCObject&&) = default ;
     LCObject& operator=(LCObject const&) = default ;
 
     /** Returns an object id for internal (debugging) use in LCIO.

--- a/src/cpp/include/pre-generated/EVENT/MCParticle.h
+++ b/src/cpp/include/pre-generated/EVENT/MCParticle.h
@@ -8,7 +8,6 @@
 #define EVENT_MCPARTICLE_H 1
 
 #include "EVENT/LCObject.h"
-#include "EVENT/MCParticle.h"
 #include "empty_ignore.h"
 
 #include <vector>

--- a/src/cpp/include/pre-generated/EVENT/ReconstructedParticle.h
+++ b/src/cpp/include/pre-generated/EVENT/ReconstructedParticle.h
@@ -10,7 +10,6 @@
 #include "EVENT/Cluster.h"
 #include "EVENT/LCObject.h"
 #include "EVENT/ParticleID.h"
-#include "EVENT/ReconstructedParticle.h"
 #include "EVENT/Track.h"
 #include "LCIOSTLTypes.h"
 #include "empty_ignore.h"

--- a/src/cpp/include/pre-generated/EVENT/Track.h
+++ b/src/cpp/include/pre-generated/EVENT/Track.h
@@ -8,7 +8,6 @@
 #define EVENT_TRACK_H 1
 
 #include "EVENT/LCObject.h"
-#include "EVENT/Track.h"
 #include "EVENT/TrackState.h"
 #include "EVENT/TrackerHit.h"
 #include "LCIOSTLTypes.h"

--- a/src/cpp/include/pre-generated/EVENT/TrackState.h
+++ b/src/cpp/include/pre-generated/EVENT/TrackState.h
@@ -26,9 +26,6 @@ typedef std::vector<TrackState*> TrackStateVec ;
 class TrackState : public LCObject {
 
 public: 
-    /// Destructor.
-    virtual ~TrackState() = default;
-
 
     /** Useful typedef for template programming with LCIO */
     typedef TrackState lcobject_type ;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -255,7 +255,7 @@ endif()
 
 FIND_PACKAGE( CLHEP QUIET )
 IF( CLHEP_FOUND )
-    INCLUDE_DIRECTORIES( ${CLHEP_INCLUDE_DIRS} ) 
+    INCLUDE_DIRECTORIES( SYSTEM ${CLHEP_INCLUDE_DIRS} )
     ADD_LCIO_TEST( test_fourvector) 
 ELSE()
     MESSAGE( STATUS "cannot build test_fourvector: clhep not found" )


### PR DESCRIPTION
BEGINRELEASENOTES
- Pregenerated Headers: remove self-include from some headers (breaks include-what-you-use)
- LCIterator, LCRTRelations: remove template syntax causing errors in gcc13/c++20
- RunEvent, LCObject, TrackStateImpl: added default copy and move constructor and assignment operator to avoid error about "'definition of implicit copy constructor for 'LCObject' is deprecated because it has a user-declared destructor'"

ENDRELEASENOTES

Fixes for example
```
In file included from /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/pre-generated/EVENT/LCObject.h:10,
                 from /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/IMPL/LCCollectionVec.h:8,
                 from /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/src/IMPL/LCCollectionVec.cc:2:
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:72:33: error: expected unqualified-id before 'const'
   72 |     LCBaseTraits<U, T, I, D, b>(const LCBaseTraits&) = delete ;
      |                                 ^~~~~
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:72:33: error: expected ')' before 'const'
   72 |     LCBaseTraits<U, T, I, D, b>(const LCBaseTraits&) = delete ;
      |                                ~^~~~~
      |                                 )
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:82:12: error: template-id not allowed for destructor
   82 |     inline ~LCBaseTraits<U, T, I, D, b>() {
      |            ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:271:23: error: expected unqualified-id before ')' token
  271 |     LCIntExtension<U>() = default ;
      |                       ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:275:5: error: template-id not allowed for destructor
  275 |     ~LCIntExtension<U>() = default ;
      |     ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:304:25: error: expected unqualified-id before ')' token
  304 |     LCFloatExtension<U>() = default ;
      |                         ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:308:5: error: template-id not allowed for destructor
  308 |     ~LCFloatExtension<U>() = default ;
      |     ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:330:24: error: expected unqualified-id before ')' token
  330 |     LCBoolExtension<U>() = default ;
      |                        ^
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-02.16.01/src/LCIO/02.16.01/src/cpp/include/LCRTRelations.h:334:5: error: template-id not allowed for destructor
  334 |     ~LCBoolExtension<U>() = default ;
      |     ^
```