### PR TITLE
Bump the minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,8 @@
 # cmake file for building LCIO
 # @author Frank Gaede, DESY
 # @author Jan Engels, DESY
-CMAKE_MINIMUM_REQUIRED( VERSION 3.0 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.14 FATAL_ERROR )
 ########################################################
-
 
 
 # project name

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,13 @@
 # cmake file for building LCIO
 # @author Frank Gaede, DESY
 # @author Jan Engels, DESY
-CMAKE_MINIMUM_REQUIRED( VERSION 2.8 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.0 FATAL_ERROR )
 ########################################################
 
 
 
 # project name
-PROJECT( LCIO )
+PROJECT( LCIO VERSION 2.20.0 )
 include(GNUInstallDirs)
 
 # project version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ CMAKE_MINIMUM_REQUIRED( VERSION 3.14 FATAL_ERROR )
 
 
 # project name
-PROJECT( LCIO VERSION 2.20.0 )
+PROJECT( LCIO )
 include(GNUInstallDirs)
 
 # project version


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum CMake version to 3.14

ENDRELEASENOTES

Right now, when running `cmake ..` I get the following warning:

``` shell
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

  PROJECT_VERSION
  PROJECT_VERSION_MAJOR
  PROJECT_VERSION_MINOR
  PROJECT_VERSION_PATCH
```

The old behaviour of having the variables is deprecated as explained here:
https://cmake.org/cmake/help/latest/policy/CMP0048.html so it may be removed in
the future but for using the new behavior we need CMake 3.0 (released in 2014).

How `VERSION` works inside `project()` is explained here: 
https://cmake.org/cmake/help/v3.21/command/project.html

so that means that this PR will keep the same behavior as before.