### PR TITLE
Fix two compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ IF( NOT SIO_FOUND )
   include(FetchContent)
   FetchContent_Declare(sio_extern
   GIT_REPOSITORY https://github.com/iLCSoft/SIO.git
-  GIT_TAG v00-01
+  GIT_TAG v00-02
   GIT_SHALLOW 1
 #  FIND_PACKAGE_ARGS
 )

--- a/src/cpp/include/IMPL/AccessChecked.h
+++ b/src/cpp/include/IMPL/AccessChecked.h
@@ -22,6 +22,7 @@ namespace IMPL {
     
   public:
     AccessChecked() ;
+    AccessChecked(const AccessChecked&) = default;
     virtual ~AccessChecked() = default;
     virtual int simpleUID() const { return _id ; }
 

--- a/src/cpp/src/IMPL/TrackImpl.cc
+++ b/src/cpp/src/IMPL/TrackImpl.cc
@@ -20,7 +20,7 @@ namespace IMPL {
         }
 
   // copy constructor
-  TrackImpl::TrackImpl(const TrackImpl& o)
+  TrackImpl::TrackImpl(const TrackImpl& o) : AccessChecked(o)
   { 
 
       *this = o ; // call operator =


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix two compiler warnings with clang

ENDRELEASENOTES

These are the warnings:

``` c++

/LCIO/sio/src/api.cc:497:17: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
      rec_buf = std::move( device.take_buffer() ) ;
                ^
/LCIO/sio/src/api.cc:497:17: note: remove std::move call here
      rec_buf = std::move( device.take_buffer() ) ;
                ^~~~~~~~~~~                     ~~

/LCIO/src/cpp/include/IMPL/AccessChecked.h:25:13: warning: definition of implicit copy constructor for 'AccessChecked' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]
    virtual ~AccessChecked() = default;
            ^
/LCIO/src/cpp/include/IMPL/TrackStateImpl.h:31:5: note: in implicit copy constructor for 'IMPL::AccessChecked' first required here
    TrackStateImpl(TrackStateImpl const&) = default ;
    ^
/LCIO/src/cpp/src/TESTS/test_trackstate.cc:85:24: note: in defaulted copy constructor for 'IMPL::TrackStateImpl' first required here
        TrackStateImpl c(b);
```