### PR TITLE
Make sure that LCIO installations are cleanly consumable with builtin SIO

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -28,3 +28,10 @@ jobs:
           make -k
           make install
           ctest --output-on-failure
+          echo "::group::Test downstream build"
+          cd -
+          export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
+          cd tests/downstream-project-cmake-test
+          mkdir build && cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17
+          make -k

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,3 +30,10 @@ jobs:
           make -k
           make install
           ctest --output-on-failure
+          echo "::group::Test downstream build"
+          cd -
+          export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
+          cd tests/downstream-project-cmake-test
+          mkdir build && cd build
+          cmake .. -DCMAKE_CXX_STANDARD=17
+          make -k

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,8 +161,8 @@ eval $*
 
 ENDIF()
 
-# Deal with SIO
-FIND_PACKAGE( SIO QUIET )
+# Deal with SIO (we need at least 0.1 since there are no targets before)
+FIND_PACKAGE( SIO 0.1 QUIET )
 
 IF( NOT SIO_FOUND )
   MESSAGE( STATUS "SIO not found on your system. Using builtin sio" )

--- a/cmake/LCIOConfig.cmake.in
+++ b/cmake/LCIOConfig.cmake.in
@@ -68,12 +68,7 @@ CHECK_PACKAGE_LIBS( LCIO lcio @CHECK_PACKAGE_SIO_LIBRARY@ )
 
 
 include(CMakeFindDependencyMacro)
-if("@CHECK_PACKAGE_SIO_LIBRARY@" STREQUAL "") 
-  find_dependency(SIO REQUIRED)
-else()
-  find_dependency(ZLIB REQUIRED)
-  include("${CMAKE_CURRENT_LIST_DIR}/SIOTargets.cmake")
-endif()
+find_dependency(SIO @SIO_VERSION@)
 
 # Include the targets file to create the imported targets that a client can link
 # to or execute

--- a/tests/downstream-project-cmake-test/CMakeLists.txt
+++ b/tests/downstream-project-cmake-test/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(DownstreamProjectUsingLCIO)
+
+find_package(LCIO REQUIRED)
+
+# Make sure that the LCIO version is set and usableas a version
+if (${LCIO_VERSION} VERSION_GREATER "0.0.0")
+  message(STATUS "Found LCIO version " ${LCIO_VERSION})
+else()
+  message(FATAL_ERROR "Cannot determine LCIO_VERSION")
+endif()
+
+add_executable(lcio_test_program lcio_test_program.cpp)
+target_link_libraries(lcio_test_program PRIVATE LCIO::lcio)

--- a/tests/downstream-project-cmake-test/lcio_test_program.cpp
+++ b/tests/downstream-project-cmake-test/lcio_test_program.cpp
@@ -1,0 +1,22 @@
+#include "EVENT/LCEvent.h"
+#include "IMPL/LCCollectionVec.h"
+#include "IMPL/LCEventImpl.h"
+#include "IMPL/MCParticleImpl.h"
+#include "MT/LCWriter.h"
+
+int main() {
+  auto mcp = new IMPL::MCParticleImpl();
+  mcp->setPDG(11);
+
+  auto coll = new IMPL::LCCollectionVec(EVENT::LCIO::MCPARTICLE);
+  coll->addElement(mcp);
+
+  auto event = new IMPL::LCEventImpl();
+  event->addCollection(coll, "mcps");
+
+  auto writer = MT::LCWriter();
+  writer.open("test.slcio");
+  writer.writeEvent(event);
+
+  return 0;
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that LCIO installations can be used in downstream projects if they are built with builtin SIO. Fixes https://github.com/iLCSoft/LCIO/issues/183
  - Add a test to make sure that this works as intended
- Bump the minimum required version for SIO to v00-01 in order to have CMake targets available.

ENDRELEASENOTES

This was probably broken in #177 and (accidentally) fixed by #181 again. This PR essentially just cleans up the `LCIOConfig.cmake.in` which has become possible after #181 (and was missed there).
