### PR TITLE
Correct case for SIOReader and LCReader "UPDATE" accessMode in docstrings.

### DIFF
--- a/src/cpp/include/SIO/SIOReader.h
+++ b/src/cpp/include/SIO/SIOReader.h
@@ -62,7 +62,7 @@ namespace SIO {
     EVENT::LCRunHeader * readNextRunHeader() override ;
 
     /** Same as readNextRunHeader() but allows to set the access mode
-     *  LCIO::READ_ONLY (default) or LCIO::Update.
+     *  EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE.
      *
      * @throws IOException
      */
@@ -77,7 +77,7 @@ namespace SIO {
 
 
     /** Same as readNextRunHeader() but allows to set the access mode
-     *  LCIO::READ_ONLY (default) or LCIO::Update
+     *  EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE
      *
      * @throws IOException
      */
@@ -135,7 +135,7 @@ namespace SIO {
     EVENT::LCRunHeader * readRunHeader(int runNumber ) override ;
 
     /** Same as LCEvent* readRunHeader(int runNumber)
-     *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
+     *  allowing to set the access mode EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE.
      *
      * @throws IOException
      */
@@ -150,7 +150,7 @@ namespace SIO {
 
 
     /** Same as LCEvent* readEvent(int runNumber, int evtNumber
-     *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
+     *  allowing to set the access mode EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE.
      *
      * @throws IOException
      */

--- a/src/cpp/include/pre-generated/IO/LCReader.h
+++ b/src/cpp/include/pre-generated/IO/LCReader.h
@@ -62,7 +62,7 @@ public:
     virtual EVENT::LCRunHeader * readNextRunHeader()  = 0;
 
     /** Same as readNextRunHeader() but allows to set the access mode 
-     *  LCIO::READ_ONLY (default) or LCIO::Update. 
+     *  EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE.
      *
      * @throws IOException
      */
@@ -76,7 +76,7 @@ public:
     virtual EVENT::LCEvent * readNextEvent()  = 0;
 
     /** Same as readNextEvent() but allows to set the access mode 
-     *  LCIO::READ_ONLY (default) or LCIO::Update. 
+     *  EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE.
      *
      * @throws IOException
      */
@@ -127,7 +127,7 @@ public:
     virtual EVENT::LCRunHeader * readRunHeader(int runNumber)  = 0;
 
     /** Same as LCEvent* readRunHeader(int runNumber) 
-     *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
+     *  allowing to set the access mode EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE.
      *
      * @throws IOException
      */
@@ -141,7 +141,7 @@ public:
     virtual EVENT::LCEvent * readEvent(int runNumber, int evtNumber)  = 0;
 
     /** Same as LCEvent* readEvent(int runNumber, int evtNumber) 
-     *  allowing to set the access mode LCIO::READ_ONLY (default) or LCIO::Update.
+     *  allowing to set the access mode EVENT::LCIO::READ_ONLY (default) or EVENT::LCIO::UPDATE.
      *
      * @throws IOException
      */


### PR DESCRIPTION
Was previously quoted as `LCIO::Update` while it is defined as ::UPDATE in `src/cpp/src/IMPL/LCIO.cc`.
Also precised that it lives in `EVENT::LCIO` namespace.