### PR TITLE
Make PIDHandler usable as a const object

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -8,11 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - release: "sw.hsf.org/key4hep"
-            CXX_STANDARD: 17
-          - release: "sw-nightlies.hsf.org/key4hep"
-            CXX_STANDARD: 20
+        release: ["sw.hsf.org/key4hep",
+                  "sw-nightlies.hsf.org/key4hep"]
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -23,7 +20,7 @@ jobs:
         run: |
           mkdir build install
           cd build
-          cmake -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
+          cmake -DCMAKE_CXX_STANDARD=20 \
             -DBUILD_ROOTDICT=ON \
             -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror " \
             -DCMAKE_INSTALL_PREFIX=../install \
@@ -36,5 +33,5 @@ jobs:
           export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
           cd tests/downstream-project-cmake-test
           mkdir build && cd build
-          cmake .. -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }}
+          cmake .. -DCMAKE_CXX_STANDARD=20
           make -k

--- a/src/cpp/include/UTIL/CollectionParameterMap.h
+++ b/src/cpp/include/UTIL/CollectionParameterMap.h
@@ -47,6 +47,7 @@ namespace UTIL{
      */
     map_type& map() { return _map ; }
 
+    const map_type& map() const { return _map; }
 
   protected:
 

--- a/src/cpp/include/UTIL/PIDHandler.h
+++ b/src/cpp/include/UTIL/PIDHandler.h
@@ -66,27 +66,27 @@ namespace UTIL{
     
     /** Return the typeID of algorithm algoName  - throws UnknownAlgorithm.
      */
-    int getAlgorithmID( const std::string& algoName ) ;
+    int getAlgorithmID( const std::string& algoName ) const ;
     
     /** Return the name of the algorithm with id  - throws UnknownAlgorithm.
      */
-    const std::string& getAlgorithmName(  int algoID ) ;
+    const std::string& getAlgorithmName(  int algoID ) const ;
 
     /** The index of parameter pName for the algorithm with algorithmID - throws UnknownAlgoritm.
      */
-    int getParameterIndex( int algorithmID, const std::string& pName ) ;
+    int getParameterIndex( int algorithmID, const std::string& pName ) const;
       
     /** Return the (first) ParticleID object for the given algorithm and particle (or cluster) - throws UnknownAlgorithm.
      *  If no object is found for the given algorithmID a default initialized dummy object is returned.
      *  Only use if you know there is only one PID object for the algorithms or if you simply want the most likely
      *  PID for this algorithm.
      */
-    const EVENT::ParticleID& getParticleID( EVENT::LCObject* particle , int algorithmID ) ;
+    const EVENT::ParticleID& getParticleID( EVENT::LCObject* particle , int algorithmID ) const ;
     
 
     /** Return all PID objects for a given algorithm - ordered with decreasing likelihood - throws UnknownAlgorithm.
      */
-    EVENT::ParticleIDVec getParticleIDs( EVENT::LCObject* p , int id ) ;
+    EVENT::ParticleIDVec getParticleIDs( EVENT::LCObject* p , int id ) const ;
 
 
     /** Set the particleID algorithm that is used for this particle's  kinematic variables 
@@ -97,11 +97,11 @@ namespace UTIL{
 
     /** The names of parameters for the algorithm with algorithmID - throws UnknownAlgoritm.
      */
-    const EVENT::StringVec&  getParameterNames( int algorithmID  ) ;
+    const EVENT::StringVec&  getParameterNames( int algorithmID  ) const;
     
     /** Return the IDs of all known Algorithms.
      */
-    const EVENT::IntVec& getAlgorithmIDs() ;
+    const EVENT::IntVec& getAlgorithmIDs() const;
 
 
     /** Set the particleID information for this particle (or cluster) - throws UnknownAlgorithm.

--- a/src/cpp/src/UTIL/PIDHandler.cc
+++ b/src/cpp/src/UTIL/PIDHandler.cc
@@ -155,9 +155,9 @@ namespace UTIL{
     return id ;
   }
   
-  int PIDHandler::getAlgorithmID( const std::string& algoName ) {
+  int PIDHandler::getAlgorithmID( const std::string& algoName ) const {
 
-    CPM::map_type::iterator it = _cpm.map().find( algoName ) ; 
+    const auto it = _cpm.map().find( algoName ) ;
     
     if( it == _cpm.map().end() ){
 
@@ -167,9 +167,9 @@ namespace UTIL{
     return it->second ;
   }
   
-  const std::string& PIDHandler::getAlgorithmName(  int algoID ) {
+  const std::string& PIDHandler::getAlgorithmName(  int algoID ) const {
     
-    CPMINV::iterator it = _cpmInv.find( algoID ) ; 
+    const auto it = _cpmInv.find( algoID ) ;
 
     if( it == _cpmInv.end() ){
       
@@ -182,10 +182,10 @@ namespace UTIL{
   
 
 
-  int PIDHandler::getParameterIndex( int algorithmID, const std::string& name ) {
+  int PIDHandler::getParameterIndex( int algorithmID, const std::string& name ) const {
     
     
-    PNM::iterator nit = _pNames.find( algorithmID ) ;
+    const auto nit = _pNames.find( algorithmID ) ;
     
     if( nit == _pNames.end() ){
 
@@ -209,9 +209,9 @@ namespace UTIL{
   }
   
   
-  const StringVec&  PIDHandler::getParameterNames( int id  ) {
+  const StringVec&  PIDHandler::getParameterNames( int id  ) const {
 
-    PNM::iterator nit = _pNames.find( id ) ;
+    const auto nit = _pNames.find( id ) ;
     
     if( nit == _pNames.end() ){
 
@@ -222,7 +222,7 @@ namespace UTIL{
     return nit->second ;
   }
     
-  const IntVec& PIDHandler::getAlgorithmIDs() {
+  const IntVec& PIDHandler::getAlgorithmIDs() const {
 
     return _ids ;
   }
@@ -231,7 +231,7 @@ namespace UTIL{
 
   void PIDHandler::setParticleIDUsed(  ReconstructedParticleImpl* p , int id  ) {
 
-    PNM::iterator nit = _pNames.find( id ) ;
+    const auto nit = _pNames.find( id ) ;
     
     if( nit == _pNames.end() ){
 
@@ -277,9 +277,9 @@ namespace UTIL{
   }
 
 
-  ParticleIDVec PIDHandler::getParticleIDs( LCObject* p , int id ) {
+  ParticleIDVec PIDHandler::getParticleIDs( LCObject* p , int id ) const {
 
-    PNM::iterator nit = _pNames.find( id ) ;
+    const auto nit = _pNames.find( id ) ;
     
     if( nit == _pNames.end() ){
       
@@ -320,9 +320,9 @@ namespace UTIL{
     return pidVID ;
   }
 
-  const ParticleID& PIDHandler::getParticleID( LCObject* p , int id ) {
+  const ParticleID& PIDHandler::getParticleID( LCObject* p , int id ) const {
 
-    PNM::iterator nit = _pNames.find( id ) ;
+    const auto nit = _pNames.find( id ) ;
     
     if( nit == _pNames.end() ){
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the `PIDHandler` usable as `const` object by marking getters that do not mutate internal state as `const`

ENDRELEASENOTES