### PR TITLE
Fix possibly wrong behavior with `std::remove_if`

### DIFF
--- a/src/cpp/src/IOIMPL/LCEventLazyImpl.cc
+++ b/src/cpp/src/IOIMPL/LCEventLazyImpl.cc
@@ -29,7 +29,7 @@ namespace IOIMPL {
   //----------------------------------------------------------------------------
   
   void LCEventLazyImpl::removeCollection(const std::string & name) {
-    std::remove_if( _blocks.begin(), _blocks.end(), [&]( const sio::block_ptr &blk ){ return (blk->name() == name) ; } ) ;
+    _blocks.erase( std::remove_if( _blocks.begin(), _blocks.end(), [&]( const sio::block_ptr &blk ){ return (blk->name() == name) ; } ), _blocks.end() ) ;
     LCEventImpl::removeCollection( name ) ;
   }
   

--- a/src/cpp/src/IOIMPL/LCEventLazyImpl.cc
+++ b/src/cpp/src/IOIMPL/LCEventLazyImpl.cc
@@ -1,6 +1,5 @@
 
 #include "IOIMPL/LCEventLazyImpl.h"
-#include "SIO/LCIORecords.h"
 #include "SIO/SIOParticleHandler.h"
 #include "SIO/SIOCollectionHandler.h"
 


### PR DESCRIPTION
Using `std::remove_if` alone only does some rearranging and changing elements of `_blocks`, and that doesn't seem what's intended there. If everyone is using C++20 `std::erase_if` can be used instead of the `erase - remove` idiom.

BEGINRELEASENOTES
- Fix possibly wrong behavior with `std::remove_if` with a `erase - remove` idiom

ENDRELEASENOTES