### PR TITLE
Make it possible to patch ParticleID meta information when patching collections

### DIFF
--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -73,9 +73,24 @@ namespace UTIL {
     /// ReconstructedParticle and where the direction of the relation has been
     /// reversed.
     struct PIDMeta {
-      std::string name{}; ///< algorithm name
+      // c++17 doesn't yet have aggregate initialization in vectors, so we
+      // need this constructor
+      PIDMeta(const std::string &n, const std::vector<std::string> &parN,
+              uint32_t c = 0)
+          : name(n), paramNames(parN), count(c) {}
+
+      // Since we have one non-default constructor we need to default the rest
+      // explicitly
+      constexpr PIDMeta() = default;
+      PIDMeta(const PIDMeta &) = default;
+      PIDMeta &operator=(const PIDMeta &) = default;
+      PIDMeta(PIDMeta &&) = default;
+      PIDMeta &operator=(PIDMeta &&) = default;
+      ~PIDMeta() = default;
+
+      std::string name{};                    ///< algorithm name
       std::vector<std::string> paramNames{}; ///< parameter names
-      uint32_t count{}; ///< How often this was found
+      uint32_t count{};                      ///< How often this was found
     };
 
   private:

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -60,7 +60,7 @@ namespace UTIL {
       _patchCols.emplace_back( std::move(name), std::move(type) ) ;
     }
 
-    /** Add a all collections as Vector(name,type), e.g. retrieved from getMissingCollections()  that should be added to events in patchEvent().
+    /** Add all collections as Vector(name,type), e.g. retrieved from getMissingCollections()  that should be added to events in patchEvent().
      */
     void addPatchCollections(Vector cols){
       for(auto&& p : cols)

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -58,16 +58,11 @@ namespace UTIL {
 
     /** Add a collection with (name,type) that should be added to events in patchEvent().
      */
-    void addPatchCollection(std::string name, std::string type){
-      _patchCols.emplace_back( std::move(name), std::move(type) ) ;
-    }
+    void addPatchCollection(std::string name, std::string type);
 
     /** Add all collections as Vector(name,type), e.g. retrieved from getMissingCollections()  that should be added to events in patchEvent().
      */
-    void addPatchCollections(Vector cols){
-      for(auto&& p : cols)
-	_patchCols.emplace_back( std::move(p) ) ;
-    }
+    void addPatchCollections(Vector cols);
 
     /** Add and empty collection to the event for any collection that is in patchCollections and not in the Event  
      */
@@ -86,6 +81,11 @@ namespace UTIL {
   private:
 
     void insertParticleIDMetas(const UTIL::PIDHandler& pidHandler, const std::string& recoName);
+
+    /// Sort the patch collections, such that all ParticleID patches are done at
+    /// the end **after** the ReconstructedParticle collections have been
+    /// patched in
+    void sortPatchCollections();
 
     unsigned _nEvents =0 ;
     std::unordered_map< std::string, std::pair< std::string, unsigned > > _map{} ;

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -3,15 +3,14 @@
 
 #include "lcio.h"
 
-#include "UTIL/PIDHandler.h"
-
 #include <string>
 #include <unordered_map>
 #include <set>
 
 namespace UTIL {
 
-  
+class PIDHandler;
+
 /** Utility class for checking and patching events with respect to collections that are not present 
  *  in every event of a set of files. 
  *  

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -82,11 +82,6 @@ namespace UTIL {
 
     void insertParticleIDMetas(const UTIL::PIDHandler& pidHandler, const std::string& recoName);
 
-    /// Sort the patch collections, such that all ParticleID patches are done at
-    /// the end **after** the ReconstructedParticle collections have been
-    /// patched in
-    void sortPatchCollections();
-
     unsigned _nEvents =0 ;
     std::unordered_map< std::string, std::pair< std::string, unsigned > > _map{} ;
     /// Map from ReconstructedParticle collection names to attached ParticleID

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -57,6 +57,23 @@ namespace UTIL {
     Vector getConsistentCollections() const ;
 
     /** Add a collection with (name,type) that should be added to events in patchEvent().
+     *
+     * Depending on the contents of name and type one of the following things
+     * will happen:
+     *
+     * - if type is an LCIO type an empty collection of the given type will be
+         put into the event using the passed name
+     * - if type is `LCRelation[<from-type>,<to-type>]` an LCRelation collection
+     *   will be created setting the <from-type> and <to-type> as FromType and
+     *   ToType collection parameters.
+     * - if type contains a '|' the whole (name, type) pair will be considered
+     *   to be ParticleID meta information and the name will be used as a PID
+     *   algorithm name and the type information will be parsed as
+     *   <reco-coll-name>|[<param-name>,<param-names...>], I.e. a ParticleID
+     *   algorithm of name will be attached to the ReconstructedParticle
+     *   collection with name <reco-coll-name>. Additionally any parameter names
+     *   that are in the comma-separated list after the '|' will be set via the
+     *   PIDHandler for this ParticleID algorithm
      */
     void addPatchCollection(std::string name, std::string type);
 

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -56,15 +56,15 @@ namespace UTIL {
 
     /** Add a collection with (name,type) that should be added to events in patchEvent().
      */
-    void addPatchCollection(const std::string name, std::string type){
-      _patchCols.push_back( {name, type} ) ;
+    void addPatchCollection(std::string name, std::string type){
+      _patchCols.emplace_back( std::move(name), std::move(type) ) ;
     }
 
     /** Add a all collections as Vector(name,type), e.g. retrieved from getMissingCollections()  that should be added to events in patchEvent().
      */
     void addPatchCollections(Vector cols){
-      for(const auto& p : cols)
-	_patchCols.push_back( p ) ;
+      for(auto&& p : cols)
+	_patchCols.emplace_back( std::move(p) ) ;
     }
 
     /** Add and empty collection to the event for any collection that is in patchCollections and not in the Event  

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -72,8 +72,6 @@ namespace UTIL {
     /** Add and empty collection to the event for any collection that is in patchCollections and not in the Event  
      */
     void patchCollections(EVENT::LCEvent* evt ) const ;
-    
-  private:
 
     /// Metadata for ParticleIDs that are handled via the PIDHandler. Necessary
     /// for consistency with EDM4hep, where ParticleID no longer lives in
@@ -84,6 +82,8 @@ namespace UTIL {
       std::vector<std::string> paramNames{}; ///< parameter names
       uint32_t count{}; ///< How often this was found
     };
+
+  private:
 
     void insertParticleIDMetas(const UTIL::PIDHandler& pidHandler, const std::string& recoName);
 

--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -3,6 +3,8 @@
 
 #include "lcio.h"
 
+#include "UTIL/PIDHandler.h"
+
 #include <string>
 #include <unordered_map>
 #include <set>
@@ -72,9 +74,25 @@ namespace UTIL {
     void patchCollections(EVENT::LCEvent* evt ) const ;
     
   private:
+
+    /// Metadata for ParticleIDs that are handled via the PIDHandler. Necessary
+    /// for consistency with EDM4hep, where ParticleID no longer lives in
+    /// ReconstructedParticle and where the direction of the relation has been
+    /// reversed.
+    struct PIDMeta {
+      std::string name{}; ///< algorithm name
+      std::vector<std::string> paramNames{}; ///< parameter names
+      uint32_t count{}; ///< How often this was found
+    };
+
+    void insertParticleIDMetas(const UTIL::PIDHandler& pidHandler, const std::string& recoName);
+
     unsigned _nEvents =0 ;
     std::unordered_map< std::string, std::pair< std::string, unsigned > > _map{} ;
-    Vector _patchCols {} ;
+    /// Map from ReconstructedParticle collection names to attached ParticleID
+    /// meta information
+    std::unordered_map<std::string, std::vector<PIDMeta>> _particleIDMetas{};
+    Vector _patchCols{};
 
   }; // class
 

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -32,13 +32,14 @@ void CheckCollections::checkFile(const std::string &fileName, bool quiet) {
       if (it == _map.end()) {
 
         auto col = evt->getCollection(name);
+        auto typeString = col->getTypeName();
+
         // If the type of a collection is LCRelation we want to read the entire
         // collections instead of just the header to get the 'ToType' and
         // 'FromType'. setReadCollectionNames({name}) allows reading of only
         // certain collections by name instead of an entire event. This flag has
         // to be unset after reading in order for the reading of the headers to
         // function properly.
-        std::string typeString;
         if (col->getTypeName() == "LCRelation") {
           lcReader.setReadCollectionNames({name});
           auto fullEvt =
@@ -57,8 +58,6 @@ void CheckCollections::checkFile(const std::string &fileName, bool quiet) {
             }
           }
           typeString = "LCRelation[" + fromType + "," + toType + "]";
-        } else {
-          typeString = col->getTypeName();
         }
         std::tie(it, std::ignore) =
             _map.emplace(name, std::make_pair(std::move(typeString), 0));

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -2,176 +2,192 @@
 
 #include "lcio.h"
 
-#include "MT/LCReader.h"
 #include "IMPL/LCCollectionVec.h"
+#include "MT/LCReader.h"
 
 #include <iomanip>
 
-namespace UTIL{
+namespace UTIL {
 
-  void CheckCollections::checkFiles( const std::vector<std::string>& fileNames, bool quiet){
+void CheckCollections::checkFiles(const std::vector<std::string> &fileNames,
+                                  bool quiet) {
 
-    for( auto n : fileNames )
-      checkFile( n ,quiet) ;
-  }
+  for (auto n : fileNames)
+    checkFile(n, quiet);
+}
 
-  void CheckCollections::checkFile( const std::string& fileName, bool quiet){
+void CheckCollections::checkFile(const std::string &fileName, bool quiet) {
 
-    MT::LCReader lcReader(MT::LCReader::directAccess) ;
-    lcReader.open( fileName ) ;
-    //----------- the event loop -----------
-    while( const auto evt = lcReader.readNextEventHeader() ) {
+  MT::LCReader lcReader(MT::LCReader::directAccess);
+  lcReader.open(fileName);
+  //----------- the event loop -----------
+  while (const auto evt = lcReader.readNextEventHeader()) {
 
-      const auto* colNames = evt->getCollectionNames() ;
+    const auto *colNames = evt->getCollectionNames();
 
-      for(const auto& name : *colNames){
+    for (const auto &name : *colNames) {
 
-	auto it = _map.find( name ) ;
+      auto it = _map.find(name);
 
-	if( it == _map.end() ){
+      if (it == _map.end()) {
 
-	  auto col = evt->getCollection( name ) ;
-    // If the type of a collection is LCRelation we want to read the entire
-    //  collections instead of just the header to get the 'ToType' and
-    //  'FromType'. setReadCollectionNames({name}) allows reading of only
-    //  certain collections by name instead of an entire event. This flag has to
-    //  be unset after reading in order for the reading of the headers to
-    //  function properly.
-    std::string typeString;
-    if (col->getTypeName() == "LCRelation"){
-      lcReader.setReadCollectionNames({name});
-      auto fullEvt = lcReader.readEvent(evt->getRunNumber(), evt->getEventNumber());
-      lcReader.setReadCollectionNames({});
+        auto col = evt->getCollection(name);
+        // If the type of a collection is LCRelation we want to read the entire
+        // collections instead of just the header to get the 'ToType' and
+        // 'FromType'. setReadCollectionNames({name}) allows reading of only
+        // certain collections by name instead of an entire event. This flag has
+        // to be unset after reading in order for the reading of the headers to
+        // function properly.
+        std::string typeString;
+        if (col->getTypeName() == "LCRelation") {
+          lcReader.setReadCollectionNames({name});
+          auto fullEvt =
+              lcReader.readEvent(evt->getRunNumber(), evt->getEventNumber());
+          lcReader.setReadCollectionNames({});
 
-      auto fullcol = fullEvt->getCollection( name ) ;
-      const auto& params = fullcol->getParameters();
-      const auto& fromType = params.getStringVal("FromType");
-      const auto& toType = params.getStringVal("ToType");
-      if (quiet == false){
-        if (fromType == ""|| toType == ""){
-          std::cout<< "WARNING! : Relation " << name <<" does not have the 'FromType' and 'ToType' set."<<std::endl;
-        }
-      }
-      typeString = "LCRelation["+fromType+","+toType+"]";
-    }
-    else {
-      typeString = col->getTypeName();
-    }
-	  const auto[ itx, _ ] = _map.emplace( name,  std::make_pair( std::move(typeString) , 0 )  ) ;
-
-	  it = itx ;
-	}
-
-	it->second.second ++ ;
-      }
-
-      _nEvents ++ ;
-    }
-
-    lcReader.close() ;
-  }
-
-
-  CheckCollections::Vector CheckCollections::getMissingCollections() const {
-    Vector  s ;
-    for(const auto& e : _map ){
-      if( e.second.second != _nEvents )
-	s.push_back( {e.first, e.second.first } ) ;
-    }
-    return s ;
-  }
-  
-
-  CheckCollections::Vector CheckCollections::getConsistentCollections() const {
-    Vector  s ;
-    for(auto e : _map ){
-      if( e.second.second == _nEvents )
-	s.push_back( {e.first, e.second.first }) ;
-    }
-    return s ;
-  }
-
-  // Obtain the from and to type from the encoded "LCRelation[From,To]"
-  std::tuple<std::string_view, std::string_view> getToFromType(const std::string_view fullType) {
-    auto delim = fullType.find(',');
-    constexpr auto prefixLen = 11u; // length of "LCRelation["
-
-    return {fullType.substr(prefixLen, delim - prefixLen),
-            fullType.substr(delim + 1, fullType.size() - delim - 2)}; // need to strip final "]" as well
-  }
-
-  void CheckCollections::patchCollections(EVENT::LCEvent* evt ) const {
-
-    for(const auto& [name, typeName] : _patchCols ){
-
-      try{
-        auto* coll = evt->getCollection( name ) ;
-        // For LCRelations we still have to check whether the FromType and
-        // ToType are set and correct in case they are not
-        if (coll->getTypeName() == "LCRelation") {
-          auto& params = coll->parameters();
-          if (params.getStringVal("FromType").empty() || params.getStringVal("ToType").empty()) {
-            const auto [from, to] = getToFromType(typeName);
-            params.setValue("FromType", std::string(from));
-            params.setValue("ToType", std::string(to));
+          auto fullcol = fullEvt->getCollection(name);
+          const auto &params = fullcol->getParameters();
+          const auto &fromType = params.getStringVal("FromType");
+          const auto &toType = params.getStringVal("ToType");
+          if (quiet == false) {
+            if (fromType == "" || toType == "") {
+              std::cout << "WARNING! : Relation " << name
+                        << " does not have the 'FromType' and 'ToType' set."
+                        << std::endl;
+            }
           }
+          typeString = "LCRelation[" + fromType + "," + toType + "]";
+        } else {
+          typeString = col->getTypeName();
         }
-      } catch( EVENT::DataNotAvailableException& e) {
-        //10 is the length of the String LCRelation after which the bracket is and the "ToType" and "FromType" start.
-        if (typeName.size() > 10 && typeName[10] == '[') {
-          auto relationColl = new IMPL::LCCollectionVec("LCRelation");
-          auto& params = relationColl->parameters();
+        const auto [itx, _] =
+            _map.emplace(name, std::make_pair(std::move(typeString), 0));
 
+        it = itx;
+      }
+
+      it->second.second++;
+    }
+
+    _nEvents++;
+  }
+
+  lcReader.close();
+}
+
+CheckCollections::Vector CheckCollections::getMissingCollections() const {
+  Vector s;
+  for (const auto &e : _map) {
+    if (e.second.second != _nEvents)
+      s.push_back({e.first, e.second.first});
+  }
+  return s;
+}
+
+CheckCollections::Vector CheckCollections::getConsistentCollections() const {
+  Vector s;
+  for (auto e : _map) {
+    if (e.second.second == _nEvents)
+      s.push_back({e.first, e.second.first});
+  }
+  return s;
+}
+
+// Obtain the from and to type from the encoded "LCRelation[From,To]"
+std::tuple<std::string_view, std::string_view>
+getToFromType(const std::string_view fullType) {
+  auto delim = fullType.find(',');
+  constexpr auto prefixLen = 11u; // length of "LCRelation["
+
+  return {fullType.substr(prefixLen, delim - prefixLen),
+          fullType.substr(delim + 1, fullType.size() - delim -
+                                         2)}; // need to strip final "]" as well
+}
+
+void CheckCollections::patchCollections(EVENT::LCEvent *evt) const {
+
+  for (const auto &[name, typeName] : _patchCols) {
+
+    try {
+      auto *coll = evt->getCollection(name);
+      // For LCRelations we still have to check whether the FromType and
+      // ToType are set and correct in case they are not
+      if (coll->getTypeName() == "LCRelation") {
+        auto &params = coll->parameters();
+        if (params.getStringVal("FromType").empty() ||
+            params.getStringVal("ToType").empty()) {
           const auto [from, to] = getToFromType(typeName);
           params.setValue("FromType", std::string(from));
           params.setValue("ToType", std::string(to));
-          evt->addCollection( relationColl, name ) ;
-        } else {
-          evt->addCollection( new IMPL::LCCollectionVec(typeName), name ) ;
         }
       }
-    }
-  }
+    } catch (EVENT::DataNotAvailableException &e) {
+      // 10 is the length of the String LCRelation after which the bracket is
+      // and the "ToType" and "FromType" start.
+      if (typeName.size() > 10 && typeName[10] == '[') {
+        auto relationColl = new IMPL::LCCollectionVec("LCRelation");
+        auto &params = relationColl->parameters();
 
-  
-  void CheckCollections::print(  std::ostream& os ,bool minimal) const {
-
-    unsigned width = 50 ;
-    if (minimal == false){
-    os << " ================================================================ " << std::endl ;
-    os << std::endl <<  "  " <<  _nEvents << " events read " << std::endl  ;
-    os << "     collections that are not in all events :  [# events where col is present]" << std::endl ;
-    os << " ================================================================ " << std::endl ;
-    }
-    if (minimal == false){
-      for(auto e : _map ){
-
-        if( e.second.second != _nEvents )
-    os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << " [" <<  e.second.second << "]"<< std::endl ;
+        const auto [from, to] = getToFromType(typeName);
+        params.setValue("FromType", std::string(from));
+        params.setValue("ToType", std::string(to));
+        evt->addCollection(relationColl, name);
+      } else {
+        evt->addCollection(new IMPL::LCCollectionVec(typeName), name);
       }
     }
-
-    if (minimal == false){
-    os << " ================================================================ " << std::endl ;
-    os << "     collections that are in all events : " << std::endl ;
-    os << " ================================================================ " << std::endl ;
-    }
-    if (minimal == false){
-      for(auto e : _map ){
-
-        if( e.second.second == _nEvents )
-    os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << "  [" <<  e.second.second << "]"<< std::endl ;
-      }
-    }
-    else{
-      for(auto e : _map ){
-
-	os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << std::endl ;
-    }
-    }
-    if (minimal == false){
-    os << " ================================================================ " << std::endl ;
-    }
   }
-
 }
+
+void CheckCollections::print(std::ostream &os, bool minimal) const {
+
+  unsigned width = 50;
+  if (minimal == false) {
+    os << " ================================================================ "
+       << std::endl;
+    os << std::endl << "  " << _nEvents << " events read " << std::endl;
+    os << "     collections that are not in all events :  [# events where col "
+          "is present]"
+       << std::endl;
+    os << " ================================================================ "
+       << std::endl;
+  }
+  if (minimal == false) {
+    for (auto e : _map) {
+
+      if (e.second.second != _nEvents)
+        os << "     " << std::setw(width) << std::left << e.first << " "
+           << std::setw(width) << e.second.first << " [" << e.second.second
+           << "]" << std::endl;
+    }
+  }
+
+  if (minimal == false) {
+    os << " ================================================================ "
+       << std::endl;
+    os << "     collections that are in all events : " << std::endl;
+    os << " ================================================================ "
+       << std::endl;
+  }
+  if (minimal == false) {
+    for (auto e : _map) {
+
+      if (e.second.second == _nEvents)
+        os << "     " << std::setw(width) << std::left << e.first << " "
+           << std::setw(width) << e.second.first << "  [" << e.second.second
+           << "]" << std::endl;
+    }
+  } else {
+    for (auto e : _map) {
+
+      os << "     " << std::setw(width) << std::left << e.first << " "
+         << std::setw(width) << e.second.first << std::endl;
+    }
+  }
+  if (minimal == false) {
+    os << " ================================================================ "
+       << std::endl;
+  }
+}
+
+} // namespace UTIL

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -60,10 +60,8 @@ void CheckCollections::checkFile(const std::string &fileName, bool quiet) {
         } else {
           typeString = col->getTypeName();
         }
-        const auto [itx, _] =
+        std::tie(it, std::ignore) =
             _map.emplace(name, std::make_pair(std::move(typeString), 0));
-
-        it = itx;
       }
 
       it->second.second++;

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -57,7 +57,7 @@ namespace UTIL{
     else {
       typeString = col->getTypeName();
     }
-	  const auto[ itx, inserted] = _map.emplace( name,  std::make_pair( std::move(typeString) , 0 )  ) ;
+	  const auto[ itx, _ ] = _map.emplace( name,  std::make_pair( std::move(typeString) , 0 )  ) ;
 
 	  it = itx ;
 	}

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -17,15 +17,15 @@ namespace UTIL{
 
   void CheckCollections::checkFile( const std::string& fileName, bool quiet){
 
-    MT::LCReader lcReader(MT::LCReader::directAccess) ; 
+    MT::LCReader lcReader(MT::LCReader::directAccess) ;
     lcReader.open( fileName ) ;
     //----------- the event loop -----------
     while( const auto evt = lcReader.readNextEventHeader() ) {
-      
+
       const auto* colNames = evt->getCollectionNames() ;
-      
+
       for(const auto& name : *colNames){
-	
+
 	auto it = _map.find( name ) ;
 
 	if( it == _map.end() ){
@@ -38,7 +38,7 @@ namespace UTIL{
     //  be unset after reading in order for the reading of the headers to
     //  function properly.
     std::string typeString;
-    if (col->getTypeName() == "LCRelation"){     
+    if (col->getTypeName() == "LCRelation"){
       lcReader.setReadCollectionNames({name});
       auto fullEvt = lcReader.readEvent(evt->getRunNumber(), evt->getEventNumber());
       lcReader.setReadCollectionNames({});
@@ -89,7 +89,7 @@ namespace UTIL{
 	s.push_back( {e.first, e.second.first }) ;
     }
     return s ;
-  }  
+  }
 
   // Obtain the from and to type from the encoded "LCRelation[From,To]"
   std::tuple<std::string_view, std::string_view> getToFromType(const std::string_view fullType) {
@@ -145,7 +145,7 @@ namespace UTIL{
     }
     if (minimal == false){
       for(auto e : _map ){
-        
+
         if( e.second.second != _nEvents )
     os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << " [" <<  e.second.second << "]"<< std::endl ;
       }
@@ -158,14 +158,14 @@ namespace UTIL{
     }
     if (minimal == false){
       for(auto e : _map ){
-        
+
         if( e.second.second == _nEvents )
     os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << "  [" <<  e.second.second << "]"<< std::endl ;
       }
     }
     else{
       for(auto e : _map ){
-      
+
 	os << "     " <<  std::setw(width) << std::left << e.first << " " <<std::setw(width) << e.second.first << std::endl ;
     }
     }

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -102,32 +102,32 @@ namespace UTIL{
 
   void CheckCollections::patchCollections(EVENT::LCEvent* evt ) const {
 
-    for(const auto& c : _patchCols ){
+    for(const auto& [name, typeName] : _patchCols ){
 
       try{
-        auto* coll = evt->getCollection( c.first ) ;
+        auto* coll = evt->getCollection( name ) ;
         // For LCRelations we still have to check whether the FromType and
         // ToType are set and correct in case they are not
         if (coll->getTypeName() == "LCRelation") {
           auto& params = coll->parameters();
           if (params.getStringVal("FromType").empty() || params.getStringVal("ToType").empty()) {
-            const auto [from, to] = getToFromType(c.second);
+            const auto [from, to] = getToFromType(typeName);
             params.setValue("FromType", std::string(from));
             params.setValue("ToType", std::string(to));
           }
         }
       } catch( EVENT::DataNotAvailableException& e) {
         //10 is the length of the String LCRelation after which the bracket is and the "ToType" and "FromType" start.
-        if (c.second.size() > 10 && c.second[10] == '[') {
+        if (typeName.size() > 10 && typeName[10] == '[') {
           auto relationColl = new IMPL::LCCollectionVec("LCRelation");
           auto& params = relationColl->parameters();
 
-          const auto [from, to] = getToFromType(c.second);
+          const auto [from, to] = getToFromType(typeName);
           params.setValue("FromType", std::string(from));
           params.setValue("ToType", std::string(to));
-          evt->addCollection( relationColl, c.first ) ;
+          evt->addCollection( relationColl, name ) ;
         } else {
-          evt->addCollection( new IMPL::LCCollectionVec(c.second), c.first ) ;
+          evt->addCollection( new IMPL::LCCollectionVec(typeName), name ) ;
         }
       }
     }

--- a/src/cpp/src/UTIL/CheckCollections.cc
+++ b/src/cpp/src/UTIL/CheckCollections.cc
@@ -5,6 +5,7 @@
 
 #include "IMPL/LCCollectionVec.h"
 #include "MT/LCReader.h"
+#include "UTIL/PIDHandler.h"
 
 #include <algorithm>
 #include <iomanip>


### PR DESCRIPTION

BEGINRELEASENOTES
- Add functionality to `CheckCollections` that makes it possible to add missing ParticleID algorithms to ReconstructedParticle collections
  - This makes it possible to make very consistent event contents that are necessary for conversion to EDM4hep

ENDRELEASENOTES

- [x] Documentation update

This is another ingredient for fixing https://github.com/lcfiplus/LCFIPlus/issues/69