### PR TITLE
Run key4hep CI workflows on still supported OSs

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -10,12 +10,13 @@ jobs:
       matrix:
         release: ["sw.hsf.org/key4hep",
                   "sw-nightlies.hsf.org/key4hep"]
+        container_os: [el9, ubuntu2204]
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        container: centos7
+        container: ${{ matrix.container_os }}
         view-path: /cvmfs/${{ matrix.release }}
         run: |
           mkdir build install


### PR DESCRIPTION

BEGINRELEASENOTES
- Run Key4hep CI workflows on OSs that are still supported

ENDRELEASENOTES