### PR TITLE
fix missing includes

### DIFF
--- a/src/cpp/src/EXAMPLE/dumpmctree-dot.cc
+++ b/src/cpp/src/EXAMPLE/dumpmctree-dot.cc
@@ -6,10 +6,12 @@
 #include "IOIMPL/LCFactory.h"
 
 #include <getopt.h>
+
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <iomanip>
-#include <algorithm>
+#include <sstream>
 #include <string>
 
 using namespace EVENT;


### PR DESCRIPTION


BEGINRELEASENOTES
- Fix compilation on MacOS by adding missing include in dumpmctree-dot.cc

ENDRELEASENOTES