### PR TITLE
Add LANGUAGES CXX in the top level CMakeLists.txt to prevent checking for a C compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ CMAKE_MINIMUM_REQUIRED( VERSION 3.14 FATAL_ERROR )
 
 
 # project name
-PROJECT( LCIO )
+PROJECT( LCIO LANGUAGES CXX )
 include(GNUInstallDirs)
 
 # project version


### PR DESCRIPTION
BEGINRELEASENOTES
- Add LANGUAGES CXX in the top level CMakeLists.txt to prevent checking for a C compiler.

ENDRELEASENOTES