### PR TITLE
Explicitly set an install prefix to avoid installing to the build tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ git checkout v02-15-01    ##  use a specific version
 ```sh
 mkdir build
 cd build
-cmake ..
+cmake .. -DCMAKE_INSTALL_PREFIX=../install
 make -j 4 install
 ```
 
@@ -67,8 +67,8 @@ make -j 4 install
   version of ROOT installed and initialized (*make sure you use a compatible compiler and  C++ standard*), e.g.
 
 ```sh
-. /cvmfs/ilc.desy.de/sw/x86_64_gcc82_sl6/root/6.18.04/bin/thisroot.sh
-cmake -DBUILD_ROOTDICT=ON -D CMAKE_CXX_STANDARD=17 ..
+. /cvmfs/ilc.desy.de/sw/x86_64_gcc131_el9/root/6.32.12/bin/thisroot.sh
+cmake -DBUILD_ROOTDICT=ON -D CMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=ON ..
 make -j 4 install
 cd ..
 ```


### PR DESCRIPTION

BEGINRELEASENOTES
- Update the README to explicitly set a `CMAKE_INSTALL_PREFIX` to avoid seemingly failing installs

ENDRELEASENOTES

Using `FetchContent` for sio (introduced in #181) will make `CMAKE_INSTALL_PREFIX` point to somewhere in the build tree if it's not set explicitly from the outside