### PR TITLE
Update CI workflows and switch to existing builds

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -20,14 +20,15 @@ jobs:
           - release: "sw-nightlies.hsf.org/key4hep"
             container_os: ubuntu2404
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         path: lcio
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: aidasoft/run-lcg-view@v5
       with:
         container: ${{ matrix.container_os }}
         view-path: /cvmfs/${{ matrix.release }}
+        ccache-key: ccache-key4hep-${{ matrix.container_os }}-${{ matrix.release }}
         run: |
           STARTDIR=$(pwd)
           cd $STARTDIR/lcio
@@ -37,6 +38,7 @@ jobs:
             -DBUILD_ROOTDICT=ON \
             -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror " \
             -DCMAKE_INSTALL_PREFIX=../install \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ..
           make -k
           ctest --output-on-failure
@@ -46,7 +48,8 @@ jobs:
           export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
           cd tests/downstream-project-cmake-test
           mkdir build && cd build
-          cmake .. -DCMAKE_CXX_STANDARD=20
+          cmake .. -DCMAKE_CXX_STANDARD=20 \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -k
           echo "::group::Test python bindings"
           cd $STARTDIR/lcio

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,11 +14,12 @@ jobs:
               "LCG_102/x86_64-centos7-clang12-opt",
               "LCG_102/x86_64-ubuntu2004-gcc9-opt"]
     steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: actions/checkout@v5
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: aidasoft/run-lcg-view@v5
       with:
         release-platform: ${{ matrix.LCG }}
+        ccache-key: ccache-${{ matrix.LCG }}
         run: |
           mkdir build install
           cd build
@@ -26,6 +27,7 @@ jobs:
             -DBUILD_ROOTDICT=ON \
             -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" \
             -DCMAKE_INSTALL_PREFIX=../install \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             ..
           make -k
           make install
@@ -39,5 +41,6 @@ jobs:
           export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
           cd tests/downstream-project-cmake-test
           mkdir build && cd build
-          cmake .. -DCMAKE_CXX_STANDARD=17
+          cmake .. -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           make -k

--- a/.github/workflows/python_bindings.yml
+++ b/.github/workflows/python_bindings.yml
@@ -9,11 +9,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: cvmfs-contrib/github-action-cvmfs@v3
-      - uses: aidasoft/run-lcg-view@v4
+      - uses: actions/checkout@v5
+      - uses: cvmfs-contrib/github-action-cvmfs@v5
+      - uses: aidasoft/run-lcg-view@v5
         with:
           release-platform: "LCG_101/x86_64-centos7-gcc10-opt"
+          ccache-key: ccache-python_bindings
           run: |
             mkdir build install
             cd build


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to existing Key4hep nightly builds for CI
- Add a simple test for the python bindings for Key4hep based workflows
- Switch to the latest versions for various actions
- Enable `ccache` for caching intermediate compilation results to speed up CI workflows

ENDRELEASENOTES