### PR TITLE
Add cstdint include to CheckCollections.h for uint32_t

### DIFF
--- a/src/cpp/include/UTIL/CheckCollections.h
+++ b/src/cpp/include/UTIL/CheckCollections.h
@@ -3,6 +3,7 @@
 
 #include "lcio.h"
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <set>


### PR DESCRIPTION
This new include is needed for gcc-15. The header uses the type `uint32_t`, which is defined in `cstdint`. https://en.cppreference.com/w/cpp/types/integer.html

BEGINRELEASENOTES
- Add cstdint include to CheckCollections.h for uint32_t

ENDRELEASENOTES