### PR TITLE
pyLCIO: adapt to changes in ROOT regarding libcppyy

### DIFF
--- a/src/python/pyLCIO/base/HandleExceptions.py
+++ b/src/python/pyLCIO/base/HandleExceptions.py
@@ -12,8 +12,12 @@ import ROOT
 import pyLCIO
 import pyLCIO.exceptions.Exceptions
 
+# Cope with API change with ROOT version >= 6.32
+if ROOT.gROOT.GetVersionCode() >= (6<<16) + (32<<8) :
+  from cppyy.types import Function as CPPOverload
 # Cope with API change with ROOT version >= 6.21
-if ROOT.gROOT.GetVersionCode() >= (6<<16) + (21<<8) :
+elif ROOT.gROOT.GetVersionCode() >= (6<<16) + (21<<8) :
+  # libcppyy has been moved in ROOT 6.38 and can no longer be imported
   from libcppyy import CPPOverload
 else:
   CPPOverload = ROOT.MethodProxy 


### PR DESCRIPTION
BEGINRELEASENOTES
- pyLCIO: make things compatible with ROOT 6.38

ENDRELEASENOTES

cf. https://github.com/root-project/root/issues/20287

(I haven't really tested this)
PS: but the unit tests here hopefully cover this part somehow? 