### PR TITLE
Fix missing entry in AID file for getSubdetectorHoleNumbers

### DIFF
--- a/src/aid/EVENT/Track.aid
+++ b/src/aid/EVENT/Track.aid
@@ -115,6 +115,13 @@ public interface Track extends LCObject {
      */
     public const IntVec& getSubdetectorHitNumbers() const ;
 
+    /** A vector that holds the number of holes in particular subdetectors.
+     *  The mapping of indices to subdetectors is implementation dependent.
+     *  To be used as convenient information or if holes are not stored in
+     *  the data set, e.g. DST or FastMC.
+     *  Check/set collection variable TrackSubdetectorNames for decoding the indices.
+     */
+    public const IntVec& getSubdetectorHoleNumbers() const ;
 
     /** The tracks that have been combined to this track.
      */


### PR DESCRIPTION
Currently not possible to use generated headers as new method was added in commit 0bf2a45aa only to pre-generated headers.



BEGINRELEASENOTES
- Fix missing `getSubdetectorHoleNumbers` in aid file in order to make compilation work again with generated headers (instead of pre-generated ones)

ENDRELEASENOTES