### PR TITLE
Discover SIO when finding and running tests explicitly

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(unittests_lcio PRIVATE Catch2::Catch2WithMain LCIO::lcio)
 include(Catch)
 catch_discover_tests(unittests_lcio
   TEST_PREFIX "ut_"
+  DL_PATHS $<TARGET_FILE_DIR:SIO::sio>
   PROPERTIES
-    ENVIRONMENT LD_LIBRARY_PATH=$<TARGET_FILE_DIR:LCIO::lcio>:$ENV{LD_LIBRARY_PATH}
+    ENVIRONMENT LD_LIBRARY_PATH=$<TARGET_FILE_DIR:LCIO::lcio>:$<TARGET_FILE_DIR:SIO::sio>:$ENV{LD_LIBRARY_PATH}
 )


### PR DESCRIPTION
BEGINRELEASENOTES
- Discover SIO when finding and running tests explicitly. This is necessary if SIO is not in `LD_LIBRARY_PATH`, for example, when it is built in.

ENDRELEASENOTES

I'm not sure if no one does this (I think this used to work fine?) but if I build LCIO with builtin SIO then SIO is not in `LD_LIBRARY_PATH`, so I get:
```
CMake Error at /usr/lib/cmake/Catch2/CatchAddTests.cmake:123 (message):
  Error listing tests from executable
  '/home/juanmi/Key4hep/LCSoft/LCIO/build/bin/unittests_lcio':

    Result: 127
    Output:

Call Stack (most recent call first):
  /usr/lib/cmake/Catch2/CatchAddTests.cmake:280 (catch_discover_tests_impl)
```

It makes sense; the local build of SIO is not in `LD_LIBRARY_PATH`, and even if RPATHS are set and correct (I checked) this is Catch2's discovery (`DL_PATHS` I'm not sure exactly what it does). The change in `LD_LIBRARY_PATH` is probably (didn't check) needed when rpaths are not enabled and the SIO library is not in `LD_LIBRARY_PATH`.