### PR TITLE
Add LD_LIBRARY_PATH to DL_PATHS for unittests_lcio

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(unittests_lcio PRIVATE Catch2::Catch2WithMain LCIO::lcio)
 include(Catch)
 catch_discover_tests(unittests_lcio
   TEST_PREFIX "ut_"
-  DL_PATHS $<TARGET_FILE_DIR:SIO::sio>
+  DL_PATHS $<TARGET_FILE_DIR:SIO::sio>:$ENV{LD_LIBRARY_PATH}
   PROPERTIES
     ENVIRONMENT LD_LIBRARY_PATH=$<TARGET_FILE_DIR:LCIO::lcio>:$<TARGET_FILE_DIR:SIO::sio>:$ENV{LD_LIBRARY_PATH}
 )


### PR DESCRIPTION
BEGINRELEASENOTES
- Add LD_LIBRARY_PATH to DL_PATHS for unittests_lcio to prevent failures when building in LCG stacks

ENDRELEASENOTES

I'm not sure what is special about LCG stacks (it works in Spack) but building with GCC 14 fails:

```
[ 97%] Linking CXX executable ../../bin/unittests_lcio
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio)
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio)
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `CXXABI_1.3.15' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio)
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/lib/liblcio.so.2.23)
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/lib/liblcio.so.2.23)
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `CXXABI_1.3.15' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/lib/liblcio.so.2.23)
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/install/devkey-head/SIO/HEAD/x86_64-el9-gcc14-opt/lib64/libsio.so.0.2)
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by /build/jenkins/workspace/lcg_nightly_pipeline/install/devkey-head/SIO/HEAD/x86_64-el9-gcc14-opt/lib64/libsio.so.0.2)
CMake Error at /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/_deps/catch2-src/extras/CatchAddTests.cmake:70 (message):
  Error running test executable
  '/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/bin/unittests_lcio':


    Result: 1
    Output: 

Call Stack (most recent call first):
  /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/LCIO-HEAD/src/LCIO-HEAD-build/_deps/catch2-src/extras/CatchAddTests.cmake:175 (catch_discover_tests_impl)

```

Continuation of https://github.com/iLCSoft/LCIO/pull/224.